### PR TITLE
Roundend and Shuttle Recall fixes, GS13 plant mutations fix, Modular suits tag

### DIFF
--- a/GainStation13/code/mechanics/permanent_fat.dm
+++ b/GainStation13/code/mechanics/permanent_fat.dm
@@ -32,7 +32,7 @@
 			var/mob/living/carbon/C = m
 			if(C)
 				C.perma_fat_save(C)
-	..()
+	. = ..()
 
 /obj/machinery/cryopod/despawn_occupant()
 	var/mob/living/mob_occupant = occupant
@@ -40,7 +40,7 @@
 		var/mob/living/carbon/C = mob_occupant
 		if(C)
 			C.perma_fat_save(C)
-	..()
+	. = ..()
 
 /*
 /datum/preferences/proc/perma_fat_save(character)

--- a/GainStation13/code/modules/clothing/under/jobs/modular_items.dm
+++ b/GainStation13/code/modules/clothing/under/jobs/modular_items.dm
@@ -131,48 +131,48 @@
 		U.modular_items -= src
 
 /obj/item/clothing/under/color/grey
+	name = "grey jumpsuit (Modular)"
 	modular_icon_location = 'GainStation13/icons/mob/modclothes/modular_grey.dmi'
+	desc = "A tasteful grey jumpsuit that reminds you of the good old days."
 
 /obj/item/clothing/under/color/grey/service
-	name = "service grey suit"
+	name = "service grey jumpsuit (Modular)"
 	desc = "Grey only in name"
 	color = "#6AD427"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0, WOUND = 5)
 
 /obj/item/clothing/under/color/grey/medical
-	name = "medical grey suit"
+	name = "medical grey jumpsuit (Modular)"
 	desc = "Grey only in name"
 	color = "#5A96BB"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 10, RAD = 0, FIRE = 0, ACID = 0, WOUND = 5)
 
 /obj/item/clothing/under/color/grey/cargo
-	name = "cargo grey suit"
+	name = "cargo grey jumpsuit (Modular)"
 	desc = "Grey only in name"
 	color = "#BB9042"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 80, ACID = 0, WOUND = 10)
 
 /obj/item/clothing/under/color/grey/engi
-	name = "engineering grey suit"
+	name = "engineering grey jumpsuit (Modular)"
 	desc = "Grey only in name"
 	color = "#FF8800"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 10, FIRE = 60, ACID = 20, WOUND = 5)
 
 /obj/item/clothing/under/color/grey/science
-	name = "science grey suit"
+	name = "science grey jumpsuit (Modular)"
 	desc = "Grey only in name"
 	color = "#9900FF"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 0, WOUND = 5)
 
 /obj/item/clothing/under/color/grey/security
-	name = "security grey suit"
+	name = "security grey jumpsuit (Modular)"
 	desc = "Grey only in name"
 	color = "#F4080C"
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 30, WOUND = 10)
 
 /obj/item/clothing/under/color/grey/command
-	name = "command grey suit"
+	name = "command grey jumpsuit (Modular)"
 	desc = "Grey only in name"
 	color = "#004B8F"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0, WOUND = 15)
-
-

--- a/GainStation13/code/modules/hydroponics/grown/berries.dm
+++ b/GainStation13/code/modules/hydroponics/grown/berries.dm
@@ -1,3 +1,6 @@
+/obj/item/seeds/berry
+	mutatelist = list(/obj/item/seeds/berry/glow, /obj/item/seeds/berry/poison, /obj/item/seeds/berry/blueberry)
+
 /obj/item/seeds/berry/blueberry
 	name = "pack of blueberry seeds"
 	desc = "These seeds grow into blueberry bushes."

--- a/GainStation13/code/modules/hydroponics/munchies_weed.dm
+++ b/GainStation13/code/modules/hydroponics/munchies_weed.dm
@@ -1,6 +1,11 @@
 /mob/living/carbon
 	var/nutri_mult = 1
 
+/obj/item/seeds/cannabis
+	mutatelist = list(/obj/item/seeds/cannabis/rainbow,
+						/obj/item/seeds/cannabis/death,
+						/obj/item/seeds/cannabis/munchies)
+
 /datum/plant_gene/trait/glow/orange
 	name = "Orange Bioluminescence"
 	glow_color = "#ff9166"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -5,13 +5,6 @@
 #define SERVER_LAST_ROUND "server last round"
 
 /datum/controller/subsystem/ticker/proc/gather_roundend_feedback()
-	//GS13 Process permanent fat
-	for(var/mob/m in GLOB.player_list)
-		if(iscarbon(m))
-			var/mob/living/carbon/C = m
-			if(C)
-				C.perma_fat_save(C)
-
 	gather_antag_data()
 	record_nuke_disk_location()
 	var/json_file = file("[GLOB.log_directory]/round_end_data.json")

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -668,7 +668,7 @@ SUBSYSTEM_DEF(shuttle)
 		priority_announce("The shift has come to an end and the shuttle called. [GLOB.security_level == SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, "shuttlecalled", "Priority")
 		log_game("Round end vote passed. Shuttle has been auto-called.")
 		message_admins("Round end vote passed. Shuttle has been auto-called.")
-	emergencyNoRecall = TRUE
+	//emergencyNoRecall = TRUE	//GS13 Edit - To ensure admins can recall vote-called shuttle this assignment will be skipped
 	endvote_passed = TRUE
 
 /datum/controller/subsystem/shuttle/proc/action_load(datum/map_template/shuttle/loading_template, obj/docking_port/stationary/destination_port, replace = FALSE)


### PR DESCRIPTION
Fixed roundend error due to fatness permanence saving
Fixed vote shuttle not being recallable by admins
Re-introduced munchies weed and blueberries and potential mutations for cannabis and berries respectively
Added (Modular) to the grey jumpsuits to mark their state as modular items