### PR TITLE
Endround Fat Permanence fix

### DIFF
--- a/GainStation13/code/mechanics/permanent_fat.dm
+++ b/GainStation13/code/mechanics/permanent_fat.dm
@@ -2,7 +2,7 @@
 	var/savekey
 	var/ckeyslot
 
-/mob/living/carbon/proc/perma_fat_save(mob/living/carbon/character)
+/mob/living/carbon/proc/perma_fat_save()
 	var/key = savekey
 	if(!key)
 		return FALSE
@@ -13,26 +13,32 @@
 	if(!path)
 		return FALSE
 
-	if(character.ckeyslot)
-		var/slot = character.ckeyslot
+	if(ckeyslot)
+		var/slot = ckeyslot
 		S.cd = "/character[slot]"
 
 		var/persi
 		S["weight_gain_persistent"] >> persi
 		if(persi)
-			WRITE_FILE(S["starting_weight"]			, character.fatness_real)
+			WRITE_FILE(S["starting_weight"]			, fatness_real)
+			to_chat(src, span_notice("Your starting weight has been updated!"))
 		var/perma
 		S["weight_gain_permanent"] >> perma
 		if(S["weight_gain_permanent"])
-			WRITE_FILE(S["permanent_fat"]			, character.fatness_perma)
+			WRITE_FILE(S["permanent_fat"]			, fatness_perma)
+			to_chat(src, span_notice("Your permanent fat has been updated!"))
 
-/datum/controller/subsystem/ticker/gather_roundend_feedback()
+/mob/living/carbon/proc/queue_perma_save()
+	to_chat(src,"Your permanence options are being saved, please wait." )
+	addtimer(CALLBACK(src, PROC_REF(perma_fat_save), TRUE, silent), 3 SECONDS, TIMER_STOPPABLE)
+
+/datum/controller/subsystem/ticker/declare_completion()
+	. = ..()
 	for(var/mob/m in GLOB.player_list)
 		if(iscarbon(m))
 			var/mob/living/carbon/C = m
 			if(C)
-				C.perma_fat_save(C)
-	. = ..()
+				C.queue_perma_save()
 
 /obj/machinery/cryopod/despawn_occupant()
 	var/mob/living/mob_occupant = occupant


### PR DESCRIPTION
Fixed an issue with roundend fat permanence that overwrote the newly added information
Added timers to ensure the saving happens at the appropriate time and messages to let players know when the saving begins and ends