### PR TITLE
Service/Science Remodeling

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -292,21 +292,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "abt" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "abu" = (
 /obj/docking_port/stationary{
 	dwidth = 1;
@@ -433,8 +421,12 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "abN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -2696,6 +2688,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "ajv" = (
@@ -3821,6 +3816,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"amA" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/command/heads_quarters/rd)
 "amB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -4152,6 +4155,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"anR" = (
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "anS" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -4237,11 +4244,6 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"aoe" = (
-/obj/machinery/space_heater,
-/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aof" = (
@@ -4538,9 +4540,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aoN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/loading_area{
 	icon_state = "steel_decals3"
 	},
@@ -4554,6 +4553,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -4771,14 +4773,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "apA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/sign/plaques/kiddie/library{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -5290,22 +5292,22 @@
 /turf/open/floor/carpet,
 /area/maintenance/fore)
 "arG" = (
-/obj/structure/closet,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = -8;
+	pixel_y = 12
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/area/maintenance/starboard/fore)
+/turf/open/floor/wood,
+/area/service/theater)
 "arH" = (
-/obj/structure/rack,
-/obj/item/extinguisher,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/airalarm{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/service/theater)
 "arI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/costume,
@@ -5755,12 +5757,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
-"asB" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "asP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -5802,17 +5798,23 @@
 /turf/open/floor/carpet,
 /area/maintenance/fore)
 "atd" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/mime,
+/obj/structure/chair/wood/wings{
+	dir = 4
 	},
-/area/maintenance/starboard/fore)
+/turf/open/floor/wood,
+/area/service/theater)
 "ate" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "atj" = (
-/obj/machinery/space_heater,
+/obj/structure/trash_pile,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -6111,25 +6113,8 @@
 	},
 /area/maintenance/fore)
 "auo" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/starboard/fore)
-"aup" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"auq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/wood,
+/area/service/theater)
 "aur" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -6146,10 +6131,18 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aus" = (
-/obj/structure/closet,
-/obj/item/stock_parts/matter_bin,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table/wood,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/clothing/mask/cigarette/pipe,
+/obj/item/clothing/mask/horsehead,
+/obj/item/clothing/mask/fakemoustache,
+/turf/open/floor/wood,
+/area/service/theater)
 "aut" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Storage Room";
@@ -6228,9 +6221,24 @@
 	},
 /area/maintenance/port/fore)
 "auH" = (
-/obj/structure/sign/poster,
-/turf/closed/wall/r_wall,
-/area/science/explab)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/chair/stool{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/science/research)
 "auI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -6466,18 +6474,38 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "avq" = (
-/obj/item/cigbutt,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/book/manual/fatty_chems,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/camera{
+	c_tag = "Theatre - Backstage";
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/structure/table/wood,
+/obj/item/clothing/mask/pig,
+/obj/item/bikehorn,
+/turf/open/floor/wood,
+/area/service/theater)
 "avr" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard)
 "avs" = (
-/obj/machinery/vending/kink,
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 12
+	},
 /turf/open/floor/carpet/black,
 /area/service/bar)
 "avt" = (
@@ -6492,6 +6520,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/fore)
@@ -6774,9 +6805,9 @@
 	},
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
+	dir = 4;
 	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	dir = 4
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -7050,12 +7081,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "awI" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Storage Room";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/service/theater)
 "awJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -7135,9 +7162,9 @@
 	},
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
+	dir = 4;
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13";
-	dir = 4
+	req_access_txt = "10; 13"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -7500,15 +7527,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "axP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 18
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/fore)
@@ -7563,6 +7594,12 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/miningoffice)
+"ayl" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "aym" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -7862,6 +7899,9 @@
 	dir = 4
 	},
 /obj/item/cigbutt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/fore)
 "azB" = (
@@ -8156,8 +8196,17 @@
 /obj/machinery/airalarm{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -8216,8 +8265,8 @@
 	height = 5;
 	name = "mining shuttle bay";
 	roundstart_template = /datum/map_template/shuttle/mining/box;
-	width = 7;
-	shuttle_id = "mining_home"
+	shuttle_id = "mining_home";
+	width = 7
 	},
 /turf/open/space/basic,
 /area/space)
@@ -8228,16 +8277,16 @@
 	height = 5;
 	name = "fore bay 1";
 	roundstart_template = /datum/map_template/shuttle/labour/box;
-	width = 9;
-	shuttle_id = "laborcamp_home"
+	shuttle_id = "laborcamp_home";
+	width = 9
 	},
 /turf/open/space/basic,
 /area/space)
 "aAW" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	dir = 4
+	dir = 4;
+	name = "Labor Camp Shuttle Airlock"
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
@@ -9623,9 +9672,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
+	dir = 4;
 	name = "Security-Storage Backroom";
-	req_access_txt = "63";
-	dir = 4
+	req_access_txt = "63"
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
@@ -9797,14 +9846,15 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "aJA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/loading_area{
+	dir = 5;
+	icon_state = "steel_decals4"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/effect/turf_decal/loading_area{
+	dir = 6;
+	icon_state = "steel_decals6"
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -9864,8 +9914,24 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aJW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research/glass{
+	id_tag = "scibrbolt1";
 	name = "Research Break Room"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -9947,6 +10013,18 @@
 /area/maintenance/starboard/fore)
 "aKM" = (
 /obj/machinery/deepfryer,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -10476,6 +10554,15 @@
 	dir = 1
 	},
 /area/command/gateway)
+"aPf" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aPl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -11158,6 +11245,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"aUo" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aUv" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
@@ -11432,6 +11529,9 @@
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVp" = (
@@ -11465,20 +11565,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"aVt" = (
-/obj/structure/table/wood,
-/obj/item/ashtray{
-	name = "candle holder";
-	pixel_y = 4
-	},
-/obj/item/candle{
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/food/snacks/bbqribs{
-	pixel_y = -8
-	},
-/turf/open/floor/wood,
-/area/service/bar)
 "aVu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11986,9 +12072,15 @@
 /area/ai_monitored/turret_protected/ai)
 "aWM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aWN" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aWO" = (
@@ -13085,6 +13177,9 @@
 	uses = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aZV" = (
@@ -13180,18 +13275,42 @@
 /area/hallway/secondary/entry)
 "baa" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bab" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bac" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bad" = (
 /obj/structure/cable/yellow{
@@ -13232,11 +13351,9 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "bai" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/theater)
 "baj" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -13606,6 +13723,7 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bbb" = (
@@ -13800,12 +13918,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bcc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bcg" = (
@@ -13838,6 +13958,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bcs" = (
@@ -13850,9 +13971,7 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "bct" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bcM" = (
@@ -13941,6 +14060,9 @@
 	dir = 8
 	},
 /obj/item/book/manual/gato_spacelaw,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "bcZ" = (
@@ -14119,10 +14241,13 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/central)
 "bdO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14132,11 +14257,13 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "floor_whole"
+	},
 /area/hallway/primary/central)
 "bdQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -14146,8 +14273,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bem" = (
@@ -14255,6 +14382,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/paper,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "beM" = (
@@ -14276,7 +14404,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "beO" = (
-/obj/structure/chair/office/dark,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -14478,50 +14605,24 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bfK" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/map/left{
-	icon_state = "map-left-MS";
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/starboard)
+/turf/closed/wall,
+/area/commons/fitness/recreation)
 "bfL" = (
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
-	icon_state = "map-right-MS";
+/obj/structure/dresser,
+/obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/starboard)
+/turf/open/floor/wood,
+/area/service/theater)
 "bfM" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bfN" = (
@@ -14591,6 +14692,12 @@
 /area/ai_monitored/turret_protected/ai)
 "bgi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bgj" = (
@@ -14690,41 +14797,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"bgy" = (
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
 "bgz" = (
-/obj/item/paper,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	name = "Arrivals Security Checkpoint";
-	pixel_y = -8;
-	req_access_txt = "1"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/chair/office/dark,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "bgA" = (
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/structure/table/reinforced,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -14944,74 +15025,51 @@
 /obj/machinery/firealarm{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Tech Storage"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bhK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/loading_area{
+	icon_state = "steel_decals5"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "floor_trim"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bhM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -15024,12 +15082,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhP" = (
@@ -15039,25 +15095,24 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/primary/starboard";
+	dir = 1;
+	name = "Starboard Hallway APC";
+	pixel_y = 26
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=14-Starboard-Central";
 	location = "13.3-Engineering-Central"
@@ -15103,6 +15158,9 @@
 	network = list("aicore")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "biq" = (
@@ -15188,6 +15246,20 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/pen{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Arrivals Security Checkpoint";
+	req_access_txt = "1"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "biB" = (
@@ -15264,12 +15336,14 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bjl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15281,6 +15355,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjn" = (
@@ -15290,6 +15367,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -15305,13 +15385,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bjp" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15323,8 +15397,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -15332,20 +15406,20 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bjs" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15360,45 +15434,42 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bju" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bjv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 2
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bjw" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_whole"
+	},
 /area/hallway/primary/starboard)
 "bjx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15409,26 +15480,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"bjz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bjA" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bjB" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15439,6 +15490,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bjC" = (
@@ -15448,8 +15505,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -15460,6 +15520,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bjE" = (
@@ -15467,7 +15536,6 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -15491,6 +15559,9 @@
 	id = "AI";
 	pixel_x = -24;
 	pixel_y = 28
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -15701,17 +15772,32 @@
 	},
 /area/hallway/primary/port)
 "bkx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bky" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	dir = 8;
+	name = "Head of Personnel";
+	req_access_txt = "57"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/command/heads_quarters/hop)
+"bky" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bkA" = (
@@ -15724,13 +15810,11 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bkQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bkR" = (
@@ -15741,24 +15825,15 @@
 	codes_txt = "patrol;next_patrol=13.1-Engineering-Enter";
 	location = "12-Central-Starboard"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bkS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bkT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	dir = 8;
@@ -15769,38 +15844,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bkU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bkV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bkW" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bkX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
@@ -15812,61 +15856,44 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bkY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bkZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bla" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"blb" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Auxiliary Tool Storage";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"bkZ" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"blc" = (
+"bla" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals5"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "floor_trim"
+	},
+/area/hallway/primary/starboard)
+"blb" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -15878,22 +15905,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ble" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "blf" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Engineering";
 	dir = 1
@@ -15904,9 +15927,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "blg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=13.2-Tcommstore";
 	location = "13.1-Engineering-Enter"
@@ -15921,17 +15941,17 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bli" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16042,6 +16062,9 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "blG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "blH" = (
@@ -16076,6 +16099,9 @@
 	pixel_x = 28
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "blT" = (
@@ -16266,6 +16292,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/maintenance/central)
+"bmG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "bmJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/status_display/evac{
@@ -16287,15 +16324,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmQ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;25;46"
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
 	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/theater)
 "bmT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16303,6 +16343,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;25;46"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bmU" = (
@@ -16313,7 +16356,6 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "bmV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -16329,6 +16371,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bmX" = (
@@ -16339,14 +16383,24 @@
 	dir = 8;
 	sortType = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"bna" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "bno" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/space,
@@ -16524,11 +16578,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bnX" = (
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bnY" = (
@@ -16709,20 +16763,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boV" = (
-/obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/keg,
+/obj/item/cigbutt,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/starboard/fore)
 "boW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -16732,40 +16783,45 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
-"boX" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
 "boY" = (
-/obj/structure/closet/firecloset,
+/obj/structure/chair/sofa/corp/corner,
+/obj/item/storage/pill_bottle/penis_enlargement{
+	pixel_x = 12
+	},
+/obj/item/storage/pill_bottle/breast_enlargement{
+	pixel_x = 12;
+	pixel_y = -10
+	},
+/turf/open/floor/carpet/black,
+/area/service/bar)
+"boZ" = (
+/obj/structure/sign/poster/contraband/clown{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/service/theater)
+"bpa" = (
+/obj/structure/closet/firecloset{
+	pixel_x = 0
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"boZ" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/service/bar)
-"bpa" = (
-/obj/machinery/light/small{
-	bulb_colour = "#FF3232";
-	color = "#FF3232";
-	dir = 1;
-	light_color = "#FF3232"
-	},
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/carpet/black,
-/area/service/bar)
 "bpb" = (
-/obj/structure/chair/sofa/corp/corner,
-/turf/open/floor/carpet/black,
-/area/service/bar)
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/obj/item/lipstick/jade{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/lipstick/black,
+/obj/item/lipstick/purple{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/wood,
+/area/service/theater)
 "bpc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16773,13 +16829,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bpd" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -16792,14 +16849,20 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bpf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16967,6 +17030,9 @@
 	uses = 10
 	},
 /mob/living/simple_animal/bot/secbot/pingsky,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bpQ" = (
@@ -17102,7 +17168,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bqo" = (
@@ -17112,7 +17180,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bqp" = (
@@ -17179,7 +17250,6 @@
 	name = "Aft Maintenance APC";
 	pixel_y = -24
 	},
-/obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
@@ -17255,54 +17325,28 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "brl" = (
-/obj/machinery/door/airlock/maintenance{
-	dir = 4;
-	name = "Bar Maintenance";
-	req_access_txt = "25"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/landmark/start/clown,
+/obj/structure/chair/wood/wings,
+/turf/open/floor/carpet/black,
+/area/service/theater)
 "brm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/toy/dummy,
+/obj/structure/table/wood,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/wood,
+/area/service/theater)
 "brn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/vending/kink,
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"bro" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	sortType = 19
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "brp" = (
 /obj/item/stack/cable_coil,
 /obj/structure/lattice/catwalk,
@@ -17325,22 +17369,36 @@
 /turf/open/floor/carpet/blue,
 /area/medical/patients_rooms/room_a)
 "brs" = (
-/obj/structure/chair/sofa/corp{
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"brt" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "area/crew_quarters/theatre";
+	name = "Theatre APC";
+	pixel_y = -29
+	},
+/obj/structure/closet/crate/wooden/toy,
+/obj/machinery/light/small{
+	pixel_x = -8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/wood,
+/area/service/theater)
+"bru" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
-/area/service/bar)
-"brt" = (
-/obj/structure/table/plasmaglass,
-/obj/item/clothing/under/misc/stripper,
-/turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/service/bar)
-"bru" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/service/bar)
+/turf/open/floor/wood,
+/area/service/theater)
 "brv" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/lattice/catwalk,
@@ -17387,12 +17445,20 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "brz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
@@ -17563,19 +17629,31 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bsl" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/vending/mealdor,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bsm" = (
-/obj/item/beacon,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bsn" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bso" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17584,6 +17662,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"bst" = (
+/obj/item/storage/belt/utility,
+/obj/item/stack/cable_coil/random,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/trash_pile,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bsu" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -17640,29 +17727,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bsz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bsA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bsB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -17670,12 +17753,12 @@
 /obj/machinery/firealarm{
 	pixel_y = -24
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bsC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -17683,27 +17766,30 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bsD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bsE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -17760,9 +17846,15 @@
 	codes_txt = "patrol;next_patrol=7-Command-Starboard";
 	location = "6-Port-Central"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1;
+	sortType = 15
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -17827,42 +17919,31 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bts" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
-"btt" = (
-/obj/item/storage/pill_bottle/breast_enlargement{
-	pixel_x = -12;
-	pixel_y = -10
-	},
-/obj/item/storage/pill_bottle/penis_enlargement{
-	pixel_x = -12
-	},
-/obj/item/reagent_containers/pill/butt_enlargement{
-	pixel_x = -12;
-	pixel_y = 10
-	},
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/carpet/black,
 /area/service/bar)
+"btt" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = -22
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/service/theater)
 "btu" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
-"btv" = (
-/obj/item/cigbutt,
-/obj/structure/trash_pile,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "btw" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -17870,7 +17951,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "btx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -17961,11 +18041,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "btQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	name = "Theatre Backstage";
+	req_access_txt = "46"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/service/theater)
 "btR" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
@@ -17981,8 +18067,8 @@
 /area/hallway/secondary/entry)
 "btT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -18021,49 +18107,20 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"bua" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
-"bub" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
 "buc" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Art Storage"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/port)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/commons/storage/art)
 "bud" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;27;37"
@@ -18072,10 +18129,18 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "buf" = (
 /obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "buj" = (
@@ -18089,26 +18154,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 15
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bul" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "buK" = (
@@ -18125,42 +18178,47 @@
 /area/maintenance/central)
 "buL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "buM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "buU" = (
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/black,
 /area/service/bar)
 "buX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/carpet/black,
+/area/service/bar)
+"buY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"buY" = (
-/obj/machinery/door/airlock/maintenance{
-	dir = 4;
-	req_one_access_txt = "12;25;46"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -18168,20 +18226,18 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
 /area/hallway/primary/starboard)
 "bva" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -18189,8 +18245,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
@@ -18199,7 +18255,7 @@
 	dir = 8;
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -18303,33 +18359,18 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bvz" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/trash_pile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"bvA" = (
 /obj/structure/table/wood,
 /obj/machinery/status_display/ai{
 	pixel_y = 31
 	},
 /obj/item/flashlight/lamp,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
-"bvA" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = 30
-	},
-/obj/structure/table/wood,
-/obj/item/phone{
-	desc = "Who can it be now?";
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/cigbutt/cigarbutt{
-	pixel_x = 5;
-	pixel_y = -1
-	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bvB" = (
@@ -18358,20 +18399,26 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bvE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/fore)
 "bvF" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bvG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -18388,14 +18435,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bvJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -18404,17 +18454,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bvL" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -18432,26 +18485,24 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "bvV" = (
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bvY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bwh" = (
@@ -18504,18 +18555,18 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bwJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bwJ" = (
+/obj/machinery/space_heater,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bwZ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -18542,6 +18593,8 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bxb" = (
@@ -18585,21 +18638,15 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bxr" = (
+/obj/structure/trash_pile,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"bxs" = (
 /obj/structure/chair/office/dark{
 	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
-"bxs" = (
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Telecomms Camera Monitor";
-	network = list("tcomms");
-	pixel_x = 26
-	},
-/obj/machinery/computer/telecomms/monitor{
-	dir = 8;
-	network = "tcommsat"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -18655,11 +18702,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Arrivals - Middle Arm";
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -18667,17 +18709,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bxB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -18688,8 +18727,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/camera{
+	c_tag = "Arrivals - Middle Arm";
+	dir = 1
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -18699,12 +18739,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -18734,52 +18768,44 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bxN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"bxS" = (
-/obj/item/cigbutt,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/maintenance/port";
-	name = "Port Maintenance APC";
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bxT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port)
-"bxY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/port)
+"bxT" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"bxY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/command/heads_quarters/hop)
+"byl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "byu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -18864,6 +18890,15 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
+"bze" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bzi" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -18900,29 +18935,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bzs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"bzw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bzC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19035,6 +19056,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bAz" = (
@@ -19095,11 +19118,18 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bAY" = (
-/obj/structure/filingcabinet{
-	pixel_x = 3
+/obj/machinery/computer/telecomms/server{
+	dir = 1;
+	network = "tcommsat"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -19115,11 +19145,9 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 6
+/obj/structure/filingcabinet{
+	pixel_x = 3
 	},
-/obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bBb" = (
@@ -19132,8 +19160,12 @@
 /area/space/nearstation)
 "bBc" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bBh" = (
 /obj/structure/table/wood,
@@ -19141,11 +19173,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/hallway/primary/port)
 "bBj" = (
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard)
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bBk" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19157,9 +19188,6 @@
 "bBl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
@@ -19242,6 +19270,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/goonplaque{
 	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of sentient postcards in a realm of darkness. The station model number is MSv42A-160516"
 	},
@@ -19289,6 +19320,7 @@
 	codes_txt = "patrol;next_patrol=12-Central-Starboard";
 	location = "11.1-Command-Starboard"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBW" = (
@@ -19354,36 +19386,32 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "bCG" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/hallway/secondary/entry)
 "bCH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bCI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "bCJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "bCK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19392,21 +19420,10 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bCN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bCQ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -19747,6 +19764,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDB" = (
@@ -19787,6 +19805,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bEf" = (
@@ -19842,23 +19862,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bEn" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "bEo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/item/radio/intercom{
+	pixel_y = -28
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "bEp" = (
 /obj/machinery/vending/coffee,
@@ -20284,18 +20294,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bFh" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -20306,6 +20313,13 @@
 	codes_txt = "patrol;next_patrol=7.5-Starboard-Aft-Corner";
 	location = "7-Command-Starboard"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bFi" = (
@@ -20352,6 +20366,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bFE" = (
@@ -20403,13 +20419,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bGq" = (
 /obj/machinery/door/airlock/maintenance{
+	dir = 8;
 	name = "Library Maintenance";
-	req_one_access_txt = "12;37";
-	dir = 8
+	req_one_access_txt = "12;37"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -20483,48 +20501,33 @@
 /area/hallway/secondary/command)
 "bGQ" = (
 /obj/machinery/vending/cola/random,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/black,
 /area/hallway/secondary/command)
 "bGR" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/newscaster{
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/black,
 /area/hallway/secondary/command)
 "bGS" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/black,
 /area/hallway/secondary/command)
 "bGT" = (
 /obj/machinery/door/airlock/maintenance{
@@ -20545,42 +20548,21 @@
 	},
 /turf/closed/wall,
 /area/maintenance/central)
-"bGV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bGW" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bGX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bHl" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
 "bHm" = (
 /obj/item/crowbar,
 /obj/item/wrench,
@@ -20599,6 +20581,8 @@
 	location = "13.2-Tcommstore"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bHo" = (
@@ -20623,6 +20607,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bHC" = (
@@ -20657,19 +20643,19 @@
 /area/tcommsat/server)
 "bHH" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bHI" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/status_display/evac{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -20763,14 +20749,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
 "bIs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bIv" = (
@@ -20785,21 +20774,6 @@
 /obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"bIE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
 "bIF" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -20807,6 +20781,15 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -20820,6 +20803,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -20862,27 +20854,24 @@
 /area/tcommsat/server)
 "bJi" = (
 /obj/machinery/light/small,
-/obj/item/folder,
-/obj/item/folder,
 /obj/machinery/camera{
 	c_tag = "Telecomms - Control Room";
 	dir = 1;
 	network = list("ss13","tcomms")
 	},
-/obj/structure/table/wood,
-/obj/item/pen,
+/obj/machinery/computer/telecomms/monitor{
+	dir = 1;
+	network = "tcommsat"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bJj" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;27;37"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "bJk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20909,25 +20898,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "bJp" = (
 /obj/machinery/vending/mealdor,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
-"bJq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/port)
 "bJr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -20948,6 +20925,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bJE" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "bJN" = (
 /obj/structure/chair{
 	dir = 1
@@ -21005,17 +20992,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "bKc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bKd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway - Starboard - Kitchen";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bKK" = (
@@ -21094,19 +21077,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bKW" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals - Aft Arm";
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -21166,13 +21138,8 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bLH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
-	},
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway - Starboard - Kitchen";
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21230,13 +21197,24 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "bMu" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals - Aft Arm - Far";
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/storage/tech)
 "bMv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -21261,38 +21239,44 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/sign/map/left{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-left-MS";
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bMy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/sign/map/right{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-right-MS";
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "bMz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "bMA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/sign/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -21300,19 +21284,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -21359,7 +21342,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNd" = (
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "bNs" = (
 /obj/structure/cable/yellow{
@@ -21368,7 +21352,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bNt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
@@ -21380,10 +21363,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNO" = (
@@ -21437,15 +21420,12 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bOe" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;27"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/fore)
 "bOf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -21461,13 +21441,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bOn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bOq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -21497,7 +21475,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bOO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -21511,48 +21488,18 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	req_access_txt = "13";
-	dir = 4
+	dir = 4;
+	req_access_txt = "13"
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bPf" = (
-/obj/machinery/door/airlock{
-	dir = 4;
-	name = "Theatre Backstage";
-	req_access_txt = "46"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"bPg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	sortType = 18
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "bPk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -21583,13 +21530,29 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "bPA" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/sign/map/left{
+	icon_state = "map-left-MS";
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"bPC" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"bPC" = (
+/area/maintenance/port)
+"bPD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
@@ -21600,16 +21563,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/catwalk_floor,
-/area/maintenance/port)
-"bPD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/item/storage/box/lights/mixed,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
 /area/maintenance/port)
 "bPF" = (
 /obj/structure/grille,
@@ -21648,12 +21601,26 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bPM" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/sign/map/right{
+	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
+	icon_state = "map-right-MS";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"bPO" = (
+/obj/structure/trash_pile,
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bPY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/airalarm{
@@ -21674,9 +21641,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bQy" = (
@@ -21686,16 +21650,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bQz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -21724,11 +21684,12 @@
 /turf/open/space,
 /area/solars/port/fore)
 "bRc" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/port)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bRd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21755,38 +21716,34 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "steel_decals5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "bRN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bRO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
 	dir = 4;
-	pixel_x = -24
+	icon_state = "steel_decals5"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "floor_trim"
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bSc" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
 "bSd" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
@@ -21826,13 +21783,15 @@
 /area/maintenance/port)
 "bSp" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bSq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -21902,16 +21861,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/port)
 "bSD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -21922,18 +21880,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;17"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bSQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bSR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -21946,62 +21895,61 @@
 	name = "Kitchen Maintenance";
 	req_access_txt = "28"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bTa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/blobstart,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
-"bTb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
-"bTd" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	icon_state = "2-4"
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
-"bTe" = (
-/obj/structure/disposalpipe/segment{
+"bTb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
+"bTe" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/fluff/railing,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "bTf" = (
@@ -22074,15 +22022,15 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L8"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bTD" = (
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
-/obj/machinery/vending/mealdor,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/turf/closed/wall,
+/area/service/library)
 "bTE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -22147,20 +22095,23 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/loading_area{
+	icon_state = "steel_decals5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "bTL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -22218,13 +22169,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bTQ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22249,9 +22200,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bTT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -22261,12 +22209,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bTV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/structure/sign/map/left{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
 	icon_state = "map-left-MS";
@@ -22275,12 +22223,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bTW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
 	icon_state = "map-right-MS";
@@ -22289,12 +22237,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bTX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 21
@@ -22305,9 +22251,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bTY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/button/door{
 	id = "gateshutter";
@@ -22318,38 +22261,36 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/loading_area{
+	icon_state = "steel_decals5"
+	},
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "bUa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bUb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bUc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/departments/botany{
 	pixel_x = 32;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22365,58 +22306,53 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bUs" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	sortType = 20
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "bUt" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenhydro";
+	name = "Service Shutter"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
+/turf/open/floor/plating,
+/area/service/hydroponics)
 "bUu" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/fluff/railing/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	pixel_x = -8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
@@ -22427,9 +22363,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/fluff/railing,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "bUx" = (
@@ -22608,6 +22548,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/big_gato,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bVi" = (
@@ -22618,7 +22559,6 @@
 	codes_txt = "patrol;next_patrol=8.1-Aft-to-Escape";
 	location = "8-Central-to-Aft"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bVj" = (
@@ -22644,11 +22584,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -22656,8 +22595,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -22668,74 +22616,87 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bVo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=8-Central-to-Aft";
 	location = "7.5-Starboard-Aft-Corner"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bVp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bVq" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
+"bVp" = (
 /obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bVz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/hallway/secondary/service)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bVA" = (
-/obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_access_txt = "null";
-	req_one_access_txt = "25;26;35;28"
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
+"bVB" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/turf/open/floor/plating,
-/area/hallway/secondary/service)
-"bVB" = (
-/obj/structure/rack,
-/obj/item/extinguisher,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/mask/gas,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "bVC" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -22970,10 +22931,13 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "bWo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -23021,13 +22985,13 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bWv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
 	},
@@ -23046,152 +23010,117 @@
 "bWx" = (
 /turf/open/floor/catwalk_floor,
 /area/engineering/main)
-"bWy" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bWz" = (
+"bWA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bWA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bWB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bWC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals5"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "bWD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bWE" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway - Aft-Starboard Corner";
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bWF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bWG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"bWE" = (
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bWH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/green,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bWI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+"bWF" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"bWG" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway - Aft-Starboard Corner";
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"bWH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"bWI" = (
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/newscaster{
+	pixel_y = -29
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bWJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "bWX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/obj/structure/table,
-/obj/item/storage/bag/plants,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/service/hydroponics)
 "bWY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -23200,10 +23129,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
@@ -23393,42 +23322,38 @@
 /turf/closed/wall,
 /area/security/checkpoint/medical)
 "bXM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white/side,
 /area/hallway/primary/central)
 "bXO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white/side,
 /area/hallway/primary/central)
 "bXP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/hallway/primary/central)
 "bXQ" = (
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway - Aft-Port";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -23445,17 +23370,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L6"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/plaque{
 	icon_state = "L10"
@@ -23471,122 +23395,134 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXV" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/obj/structure/sign/departments/science,
+/turf/closed/wall,
 /area/hallway/primary/central)
 "bXW" = (
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway - Aft-Starboard";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bXY" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bXZ" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bYa" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/newscaster{
-	pixel_y = -29
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"bYb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;35;47"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"bYc" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
-"bYd" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
+"bXY" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Hydroponics Storage"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bYo" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
+/turf/open/floor/plasteel/white/side,
+/area/hallway/primary/central)
+"bXZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/service)
-"bYp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/area/hallway/primary/starboard)
+"bYa" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
-"bYr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
+/obj/effect/turf_decal/loading_area{
+	dir = 6;
+	icon_state = "steel_decals6"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 5;
+	icon_state = "steel_decals4"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/bar)
+"bYb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hallway/primary/central)
+"bYc" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Hydroponics Storage"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"bYd" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/bar)
+"bYo" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
+"bYr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "bYs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bYt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -23865,21 +23801,36 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "bZb" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bZc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white/side,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bZd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white/side,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bZe" = (
 /obj/structure/sign/directions/security{
@@ -23896,13 +23847,15 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "bZf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Aft Primary Hallway"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Aft Primary Hallway"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -23911,18 +23864,21 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/door/airlock/public/glass{
 	name = "Aft Primary Hallway"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bZh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple,
 /obj/machinery/door/airlock/public/glass{
 	name = "Aft Primary Hallway"
 	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bZi" = (
@@ -23941,23 +23897,38 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/research)
-"bZk" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall,
-/area/science/research)
 "bZl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white/side,
+/obj/structure/table,
+/obj/item/clothing/glasses/science{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/screwdriver{
+	pixel_y = 16
+	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "bZm" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white/side,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "bZn" = (
 /turf/closed/wall,
@@ -23966,33 +23937,40 @@
 /turf/closed/wall,
 /area/security/checkpoint/science/research)
 "bZq" = (
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/watermelon,
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
-/obj/item/reagent_containers/food/snacks/grown/grapes,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/structure/table/glass,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bZs" = (
-/obj/item/cultivator,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
+/obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/hallway/primary/central)
 "bZy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_access_txt = "null";
-	req_one_access_txt = "25;26;35;28"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/hallway/secondary/service)
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "bZz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24000,13 +23978,25 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bZA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
-"bZB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"bZB" = (
+/obj/structure/trash_pile,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bZC" = (
@@ -24181,9 +24171,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/security/glass{
+	dir = 8;
 	name = "Medbay Security Post";
-	req_access_txt = "63";
-	dir = 8
+	req_access_txt = "63"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
@@ -24231,52 +24221,43 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"caj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = -3
-	},
+/obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/glass/bottle/charcoal{
 	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
 	pixel_y = -3
 	},
 /obj/item/reagent_containers/syringe/epinephrine{
 	pixel_x = 3;
 	pixel_y = -2
 	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"caj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics Maintenance";
+	req_access_txt = "35"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "cak" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -24332,7 +24313,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "caq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -24345,87 +24325,66 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cas" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cat" = (
-/obj/structure/table,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cau" = (
-/obj/structure/table,
-/obj/item/paper/pamphlet/gateway,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/structure/chair/beanbag,
+/obj/effect/landmark/start/assistant,
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cav" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/structure/chair/beanbag{
+	dir = 8
+	},
+/obj/item/paicard{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "caw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cax" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cay" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"caz" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/assembly/igniter{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/screwdriver{
-	pixel_y = 16
-	},
-/obj/item/gps{
-	gpstag = "RD0"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -24437,24 +24396,9 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "caB" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -24464,28 +24408,14 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research Division - Lobby";
-	network = list("ss13","rd")
+	network = list("ss13","rd");
+	pixel_y = 12
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/stock_parts/cell/potato,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "caC" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -27;
-	pixel_y = 6
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -24495,56 +24425,33 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/science/research";
+	dir = 8;
+	name = "Security Post - Research Division APC";
+	pixel_x = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the RD's goons from the safety of his office.";
+	name = "Research Monitor";
+	network = list("rd");
+	pixel_y = 24
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -24;
+	pixel_y = 20
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "caD" = (
-/obj/structure/table,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
-	},
-/obj/machinery/button/door{
-	id = "Biohazard";
-	name = "Biohazard Shutter Control";
-	pixel_x = -7;
-	req_access_txt = "47"
-	},
-/obj/machinery/button/door{
-	desc = "A remote control switch for the research division entryway.";
-	id = "ResearchExt";
-	name = "Research Exterior Airlock";
-	normaldoorcontrol = 1;
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/machinery/button/door{
-	desc = "A remote control switch for the research division entryway.";
-	id = "ResearchInt";
-	name = "Research Interior Airlock";
-	normaldoorcontrol = 1;
-	pixel_x = 7;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science/research)
-"caE" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -24552,61 +24459,81 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel,
+/area/security/checkpoint/science/research)
+"caE" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = 26
+	},
+/turf/open/floor/carpet/black,
 /area/security/checkpoint/science/research)
 "caG" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"caH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"caT" = (
-/obj/structure/disposalpipe/segment{
+"caH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	dir = 8;
-	name = "Hydroponics Maintenance";
-	req_access_txt = "35"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"caU" = (
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 21
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"caT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway - Aft-Port";
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"caU" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
@@ -24614,7 +24541,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/catwalk_floor,
@@ -24774,6 +24707,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cbD" = (
@@ -24838,9 +24774,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock{
+	dir = 4;
 	name = "Medbay Emergency Storage";
-	req_access_txt = "5";
-	dir = 4
+	req_access_txt = "5"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -24990,33 +24926,39 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cbW" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cbX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 26;
+	pixel_y = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cbY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
 "cbZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cca" = (
@@ -25024,160 +24966,124 @@
 /area/medical/medbay/central)
 "ccb" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
 /area/medical/medbay/central)
 "ccc" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/science/research)
 "ccd" = (
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cce" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ccf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"ccg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cch" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/machinery/holopad,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cci" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"ccj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cck" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
 "ccl" = (
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/item/radio/off,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "ccm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/depsec/science,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science/research)
-"ccn" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the RD's goons from the safety of his office.";
-	dir = 8;
-	name = "Research Monitor";
-	network = list("rd");
-	pixel_x = 28;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/item/book/manual/gato_spacelaw,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"ccq" = (
-/obj/structure/table,
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/machinery/light,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/machinery/camera{
-	c_tag = "Hydroponics - Foyer";
-	dir = 1
+"ccn" = (
+/obj/structure/closet/secure_closet/security/science,
+/obj/item/radio/off,
+/obj/item/screwdriver{
+	pixel_y = 10
 	},
-/obj/item/radio/intercom{
-	pixel_y = -25
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/turf/open/floor/carpet/black,
+/area/security/checkpoint/science/research)
+"ccq" = (
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/black,
 /area/hallway/primary/central)
 "ccr" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/black,
 /area/hallway/primary/central)
 "ccD" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "ccE" = (
@@ -25257,7 +25163,16 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "ccU" = (
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/structure/chair/comfy/black,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "cdb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -25506,36 +25421,37 @@
 /area/medical/medbay/central)
 "cdA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cdB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /mob/living/simple_animal/bot/medbot{
 	auto_patrol = 1;
 	desc = "A little medical robot, officially part of the GATO medical inspectorate. He looks somewhat underwhelmed.";
 	name = "Inspector Johnson"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cdC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cdD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cdE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -25544,16 +25460,27 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
 /area/medical/medbay/central)
 "cdG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25562,36 +25489,58 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cdI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cdJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cdK" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -25599,132 +25548,171 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cdM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cdN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cdO" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cdP" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "R&D Security Checkpoint";
+	req_access_txt = "1"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/pen{
+	pixel_x = -4;
+	pixel_y = 2
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
 "cdQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/landmark/start/depsec/science,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office/dark{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "cdR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science/research)
-"cdS" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
-/obj/structure/chair{
-	dir = 8
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Security Post - Research Division";
 	dir = 8;
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/button/door{
+	desc = "A remote control switch for the research division entryway.";
+	id = "ResearchExt";
+	name = "Research Exterior Airlock";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = 8
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the research division entryway.";
+	id = "ResearchInt";
+	name = "Research Interior Airlock";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/obj/machinery/button/door{
+	id = "Biohazard";
+	name = "Biohazard Shutter Control";
+	pixel_x = 24;
+	req_access_txt = "47"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
+"cdS" = (
+/turf/open/floor/wood,
+/area/service/bar)
 "cdU" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Maintenance";
-	req_access_txt = "35"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/service/hydroponics)
-"cdV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cdW" = (
-/obj/item/flashlight,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/starboard)
 "cdX" = (
 /obj/structure/closet/crate,
 /obj/item/coin/silver,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cdY" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/storage/box/lights/mixed,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cdZ" = (
@@ -26032,10 +26020,6 @@
 /area/medical/medbay/central)
 "ceH" = (
 /obj/structure/bed/roller,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ceI" = (
@@ -26045,8 +26029,8 @@
 	dwidth = 12;
 	height = 17;
 	name = "northwest of station";
-	width = 23;
-	shuttle_id = "syndicate_nw"
+	shuttle_id = "syndicate_nw";
+	width = 23
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -26062,11 +26046,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -26078,6 +26057,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "ceM" = (
@@ -26085,21 +26066,20 @@
 /turf/open/floor/wood,
 /area/service/library)
 "ceN" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ceO" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/potato,
 /obj/machinery/light,
 /obj/machinery/newscaster{
 	pixel_x = -1;
@@ -26111,121 +26091,104 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ceQ" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"ceR" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "ceS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ceT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ceU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ceV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
 "ceW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science/research)
-"ceX" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 27
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/book/manual/gato_spacelaw{
+	pixel_x = 8
+	},
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"ceY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+"ceX" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
+"ceY" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "ceZ" = (
 /obj/structure/cable/yellow{
@@ -26241,6 +26204,9 @@
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "cfb" = (
@@ -26250,8 +26216,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/catwalk_floor,
@@ -26260,14 +26232,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	sortType = 21
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
@@ -26285,81 +26260,69 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cff" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cfg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard/aft)
-"cfg" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "cfh" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	dir = 8;
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cfi" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
+/area/maintenance/starboard/aft)
+"cfi" = (
+/obj/machinery/biogenerator,
+/obj/machinery/door/window/westright{
+	dir = 4;
+	req_one_access_txt = "30;35"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenhydro";
+	name = "Service Shutter"
+	},
+/turf/open/floor/plating,
+/area/service/hydroponics)
 "cfj" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "cfk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26367,21 +26330,21 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cfl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /obj/machinery/door/airlock/maintenance/abandoned{
 	dir = 4;
 	name = "Storage Room";
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cfm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -26732,7 +26695,6 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "cgb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -26740,15 +26702,22 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/structure/sign/departments/medbay/alt{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cgc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/departments/science{
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cgd" = (
@@ -26764,15 +26733,6 @@
 /area/science/lab)
 "cgf" = (
 /obj/structure/table/reinforced,
-/obj/item/pen,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastright{
 	dir = 2;
@@ -26783,6 +26743,21 @@
 	id = "research_shutters";
 	name = "research shutters"
 	},
+/obj/item/paper_bin{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/folder/white{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/folder/white{
+	pixel_x = -6
+	},
 /turf/open/floor/plating,
 /area/science/lab)
 "cgg" = (
@@ -26792,41 +26767,28 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "cgh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "Biohazard";
-	name = "biohazard containment door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/research)
-"cgi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
 	name = "biohazard containment door"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"cgi" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Biohazard";
+	name = "biohazard containment door"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cgk" = (
-/obj/structure/closet/secure_closet/security/science,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science/research)
-"cgl" = (
-/obj/structure/filingcabinet,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -26834,15 +26796,39 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/light,
+/obj/structure/filingcabinet,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
-"cgm" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+"cgl" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 4;
+	req_one_access_txt = "12;25;46"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
+"cgm" = (
+/obj/machinery/space_heater,
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cgn" = (
@@ -26856,12 +26842,28 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "cgp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
 	req_access_txt = "47"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/maintenance/starboard/aft)
 "cgq" = (
 /turf/closed/wall/r_wall,
@@ -27163,13 +27165,6 @@
 /obj/machinery/chem_dispenser{
 	layer = 2.7
 	},
-/obj/machinery/button/door{
-	id = "chemistry_shutters";
-	name = "chemistry shutters control";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "5; 33"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -27202,12 +27197,10 @@
 /obj/item/multitool{
 	pixel_x = 3
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/noticeboard{
 	pixel_y = 31
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "chj" = (
@@ -27225,6 +27218,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "chk" = (
@@ -27234,6 +27230,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "chm" = (
@@ -27265,10 +27262,6 @@
 /area/security/checkpoint/science/research)
 "chq" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Post - Research Division";
-	req_access_txt = "63"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -27279,51 +27272,77 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/science/research)
-"chr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;47"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Post - Research Division";
+	req_access_txt = "63"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel,
+/area/security/checkpoint/science/research)
+"chr" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "chs" = (
-/obj/structure/sign/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/carpet,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/black,
 /area/science/research)
 "cht" = (
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = 32
-	},
-/obj/machinery/camera{
-	c_tag = "Research Break Room";
-	network = list("ss13","rd")
-	},
-/obj/machinery/vending/coffee,
-/turf/open/floor/carpet,
-/area/science/research)
-"chu" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
-/obj/machinery/vending/mealdor,
-/turf/open/floor/carpet,
+/turf/closed/wall/r_wall,
+/area/science/research)
+"chu" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/science/research)
 "chv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -27332,42 +27351,43 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "chy" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_decals3"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals3"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/bar)
+"chA" = (
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab - Test Chamber";
-	network = list("ss13","rd")
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/explab)
-"chA" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
+	network = list("ss13","rd");
+	pixel_y = 12
 	},
 /turf/open/floor/engine,
 /area/science/explab)
 "chB" = (
-/obj/machinery/space_heater,
-/obj/effect/landmark/blobstart,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "chC" = (
-/obj/item/storage/belt/utility,
-/obj/item/stack/cable_coil/random,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/trash_pile,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"chD" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
@@ -27378,20 +27398,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"chE" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/line{
+"chD" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"chE" = (
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "chF" = (
 /obj/structure/closet,
 /obj/item/flashlight,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "chG" = (
@@ -27635,6 +27663,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/button/door{
+	id = "chemistry_shutters";
+	name = "chemistry shutters control";
+	pixel_x = -24;
+	pixel_y = 24;
+	req_access_txt = "5; 33"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cix" = (
@@ -27680,11 +27715,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/noticeboard{
-	desc = "A board for pinning important notices upon. Probably helpful for keeping track of requests.";
-	name = "requests board";
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -27701,23 +27731,11 @@
 /obj/machinery/rnd/destructive_analyzer,
 /obj/machinery/airalarm{
 	dir = 4;
-	pixel_x = -23
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/lab)
-"ciC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "ciD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -27734,7 +27752,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ciG" = (
@@ -27744,9 +27761,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -27754,82 +27768,85 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ciH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"ciI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/science/research)
+"ciI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "floor_trim"
+	},
 /area/science/research)
 "ciK" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "ciL" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ciM" = (
-/obj/effect/landmark/blobstart,
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
+"ciP" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"ciQ" = (
+/obj/item/cigbutt,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/cigbutt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"ciO" = (
-/turf/open/floor/carpet,
-/area/science/research)
-"ciP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/science/research)
-"ciQ" = (
-/obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/science/research)
 "ciR" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/table,
-/obj/item/storage/box/donkpockets/donkpocketpizza,
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
 /area/science/research)
 "ciS" = (
@@ -27839,29 +27856,24 @@
 /area/cargo/storage)
 "ciT" = (
 /obj/item/beacon,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/engine,
 /area/science/explab)
 "ciU" = (
-/obj/machinery/rnd/experimentor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/engine,
 /area/science/explab)
 "ciV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/structure/sign/departments/medbay/alt,
+/turf/closed/wall,
+/area/security/checkpoint/medical)
 "ciW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/science/explab)
 "ciX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "ciY" = (
@@ -27903,14 +27915,10 @@
 	},
 /area/maintenance/port/aft)
 "cjr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = -8;
+	pixel_y = 12
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
@@ -27977,10 +27985,10 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/medical/glass{
+	dir = 4;
 	id_tag = "MedbayFoyer";
 	name = "Medbay";
-	req_access_txt = "5";
-	dir = 4
+	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
@@ -28183,16 +28191,13 @@
 /obj/machinery/computer/rdconsole/core{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cjY" = (
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cjZ" = (
 /obj/item/reagent_containers/glass/beaker/sulphuric,
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -28201,13 +28206,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ckb" = (
 /obj/effect/landmark/start/scientist,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -28221,60 +28224,101 @@
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/micro_laser,
 /obj/item/stock_parts/micro_laser,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "ckd" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/science/lab)
+/obj/machinery/light,
+/turf/open/floor/carpet,
+/area/service/bar)
 "cke" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"ckf" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/decal/medium_gato,
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"ckh" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/research)
-"cki" = (
-/obj/machinery/light{
+/obj/machinery/shower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "floor_trim"
+	},
+/area/science/research)
+"ckf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/medium_gato,
+/turf/open/floor/plasteel,
+/area/science/research)
+"ckh" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"cki" = (
 /obj/machinery/quantumpad{
 	map_pad_id = "station";
 	map_pad_link_id = "xenoarch";
 	name = "To Xenoarch"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ckj" = (
@@ -28283,15 +28327,9 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "ckk" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/flashlight,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/sign/departments/medbay/alt,
+/turf/closed/wall,
+/area/hallway/primary/central)
 "ckl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -28301,91 +28339,103 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port)
 "ckm" = (
-/obj/item/cigbutt,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/science/research)
-"ckn" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/burger/soylent,
-/obj/item/ashtray{
-	pixel_x = 9
-	},
-/turf/open/floor/carpet,
-/area/science/research)
-"cko" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/mob/living/simple_animal/pet/dog/pug{
+	desc = "It's Pugley IV, the research department's lovable pug clone. Hopefully nothing happens to this one - fourth time lucky!";
+	name = "Pugley IV";
+	real_name = "Pugley IV"
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/purple,
+/area/science/research)
+"cko" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/science/research)
 "ckp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/science/research)
 "ckq" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
 /area/science/research)
 "ckr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenhydro";
+	name = "Service Shutter"
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "cks" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
+"ckt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /obj/machinery/button/door{
 	id = "telelab";
 	name = "Test Chamber Blast Doors";
-	pixel_y = -25
+	pixel_x = -8;
+	pixel_y = -24
 	},
-/turf/open/floor/engine,
-/area/science/explab)
-"ckt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/explab)
 "cku" = (
-/obj/structure/closet,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "ckv" = (
-/obj/structure/closet/crate,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/item/assembly/infra,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "ckw" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
@@ -28543,12 +28593,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "ckY" = (
-/obj/structure/curtain{
-	color = "#880202";
-	opacity = 1;
-	open = 0
-	},
-/turf/open/floor/carpet/black,
+/obj/effect/landmark/start/assistant,
+/obj/structure/chair/stool/bar/bronze,
+/turf/open/floor/carpet,
 /area/service/bar)
 "ckZ" = (
 /obj/structure/disposalpipe/segment,
@@ -28747,7 +28794,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "clx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -28757,7 +28803,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cly" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Fore";
 	dir = 8
@@ -28778,7 +28823,7 @@
 /obj/item/clothing/glasses/welding,
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -28790,14 +28835,12 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "clB" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/white,
-/area/science/lab)
-"clC" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -28817,192 +28860,174 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 30
-	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "clF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel,
 /area/science/research)
 "clG" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel{
+	icon_state = "floor_trim"
+	},
 /area/science/research)
 "clI" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "clJ" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	freq = 1400;
-	location = "Research Division"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
-"clK" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/aft)
-"clL" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/item/storage/box/lights/mixed,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"clN" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/purple,
 /area/science/research)
-"clO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/pizza/meat,
-/turf/open/floor/carpet,
-/area/science/research)
-"clP" = (
-/obj/structure/disposalpipe/segment{
+"clK" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/aft)
+"clL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
+"clN" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet/purple,
 /area/science/research)
 "clQ" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/science/research)
 "clR" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
+	pixel_x = 4;
 	pixel_y = -30
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
+/obj/structure/chair/beanbag/purple{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
 /area/science/research)
 "clS" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 16
+	},
+/turf/open/floor/carpet/black,
+/area/service/hydroponics)
+"clT" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/science/explab)
-"clT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "telelab";
-	name = "test chamber blast door"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/science/explab)
 "clU" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
 	name = "test chamber blast door"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/explab)
 "clV" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "telelab";
-	name = "test chamber blast door"
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/engine,
-/area/science/explab)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "clW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
+"clX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
-"clX" = (
+"clZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /obj/machinery/door/airlock/maintenance/abandoned{
 	dir = 4;
 	name = "Storage Room";
 	req_one_access_txt = "12;47"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"clY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"clZ" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cma" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/mask/surgical,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cmb" = (
@@ -29057,7 +29082,10 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "cml" = (
 /obj/structure/sign/nanotrasen,
@@ -29150,17 +29178,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cmD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/sign/departments/chemistry{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cmE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -29185,6 +29214,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cmG" = (
@@ -29206,6 +29238,7 @@
 /obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
 /obj/item/disk/design_disk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cmI" = (
@@ -29235,124 +29268,190 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cmL" = (
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Research Division Deliveries";
-	req_access_txt = "47"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/research)
-"cmM" = (
-/obj/machinery/door/airlock{
-	name = "Research Emergency Storage";
-	req_one_access_txt = "47"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics Maintenance";
+	req_access_txt = "35"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/starboard)
+"cmM" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "cmN" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/science/research)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
 "cmO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/science/research)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engineering/break_room)
 "cmP" = (
-/turf/closed/wall,
-/area/science/explab)
-"cmQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = 30;
-	receive_ore_updates = 1
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/explab)
-"cmR" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/rnd/bepis,
-/turf/open/floor/plasteel,
-/area/science/explab)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "cmS" = (
-/obj/structure/table/reinforced,
-/obj/item/hand_labeler,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/taperecorder,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/rnd/bepis,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/explab)
 "cmT" = (
-/obj/machinery/computer/rdconsole/experiment,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/clipboard{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/folder/white{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/folder/white{
+	pixel_x = 5
+	},
+/obj/item/taperecorder{
+	pixel_x = -4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "cmU" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/book/manual/wiki/experimentor,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/landmark/start/scientist,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "cmV" = (
+/obj/machinery/computer/rdconsole/experiment{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
+"cmW" = (
 /obj/machinery/button/door{
 	id = "telelab";
 	name = "Test Chamber Blast Doors";
-	pixel_y = 25
+	pixel_x = -8;
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/healthanalyzer,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/explab)
-"cmW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/explab)
-"cmY" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/trash_pile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
+"cmY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "cmZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -29361,13 +29460,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cna" = (
-/obj/structure/rack,
-/obj/item/clothing/under/color/white,
-/obj/item/clothing/head/soft/mime,
-/obj/item/clothing/under/color/white,
-/obj/item/clothing/head/soft/mime,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cnb" = (
@@ -29604,32 +29699,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cnN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cnO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cnP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -29637,63 +29716,49 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cnQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/central)
 "cnR" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters_2";
 	name = "research shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/lab)
 "cnS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cnT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
 	},
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel/white,
-/area/science/lab)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cnU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cnV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -29709,19 +29774,24 @@
 	maxcharge = 15000
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cnX" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/science/lab)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cnY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -29731,198 +29801,158 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cnZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "coa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cob" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Research Division Hallway - Central";
-	network = list("ss13","rd")
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cob" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "coc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/table/glass,
+/obj/item/watertank,
+/obj/item/grenade/chem_grenade/antiweed,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 5
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 8;
+	pixel_y = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_y = 3
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "cod" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
-/area/science/research)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "coe" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white/side,
-/area/science/research)
-"cof" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 6
-	},
-/area/science/research)
-"cog" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"coh" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"coi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"coj" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"cok" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+"cof" = (
+/obj/machinery/status_display/ai{
+	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/vending/mealdor,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/science/research)
+"cog" = (
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/turf/open/floor/engine,
 /area/science/explab)
-"col" = (
-/obj/structure/chair/office/light{
+"coh" = (
+/obj/structure/fluff/railing{
 	dir = 4
 	},
-/mob/living/simple_animal/pet/dog/pug{
-	desc = "It's Pugley IV, the research department's lovable pug clone. Hopefully nothing happens to this one - fourth time lucky!";
-	name = "Pugley IV";
-	real_name = "Pugley IV"
+/obj/structure/trash_pile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"coi" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;25;46"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"com" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
 	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
+"coj" = (
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"con" = (
-/obj/effect/landmark/start/scientist,
-/obj/structure/chair/office/light{
-	dir = 1;
-	pixel_y = 3
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"coo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/button/door{
+	id = "research_shuttersbr";
+	name = "R&D Break Room Shutters Control";
+	pixel_x = -6;
+	pixel_y = 22;
+	req_access_txt = "7"
 	},
-/obj/structure/table/reinforced,
-/obj/item/wrench,
-/obj/item/crowbar,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/science,
-/obj/item/multitool{
-	pixel_x = 3
+/obj/machinery/button/door{
+	id = "scibrbolt1";
+	name = "R&D Break Room Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 4;
+	pixel_y = 22;
+	specialfunctions = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"cop" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 32
 	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"coq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/area/science/research)
+"com" = (
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"cop" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/explab)
+"coq" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cor" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -29935,6 +29965,9 @@
 	pixel_y = 6
 	},
 /obj/item/pen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cot" = (
@@ -29953,6 +29986,9 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cou" = (
@@ -29960,15 +29996,18 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cow" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/rnd/production/techfab/department/service,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/starboard)
 "cox" = (
 /obj/structure/mineral_door/wood{
 	name = "The Gobbetting Barmaid"
@@ -30197,7 +30236,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "coZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -30260,11 +30298,17 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cpe" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -30275,6 +30319,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cpg" = (
@@ -30282,6 +30332,12 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -30297,6 +30353,12 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cpj" = (
@@ -30309,17 +30371,28 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cpk" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"cpk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -30327,10 +30400,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cpm" = (
@@ -30340,7 +30418,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -30349,55 +30430,29 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cpo" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cpp" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cpq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cpr" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -30405,13 +30460,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cpu" = (
@@ -30421,50 +30478,129 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cpv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cpw" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction/flip{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/door/airlock/research{
+	dir = 4;
+	name = "Experimentation Lab";
+	req_access_txt = "8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cpx" = (
-/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"cpy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"cpz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/door/airlock/research{
@@ -30472,60 +30608,8 @@
 	name = "Experimentation Lab";
 	req_access_txt = "8"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"cpy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"cpz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"cpA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -30536,94 +30620,105 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"cpC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"cpD" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"cpE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"cpD" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/explab)
+"cpE" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/explab)
 "cpF" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/science/explab)
+"cpG" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
 	name = "Experimentation Lab Maintenance";
 	req_access_txt = "8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cpG" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cpH" = (
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/fluff/railing{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cpI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/item/flashlight,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cpJ" = (
 /obj/structure/barricade/wooden,
@@ -31011,6 +31106,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cqC" = (
@@ -31018,14 +31115,13 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqD" = (
@@ -31033,10 +31129,15 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -31044,204 +31145,200 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cqH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqI" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/starboard)
 "cqJ" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel,
+/area/engineering/break_room)
 "cqK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Starboard";
 	dir = 1;
 	network = list("ss13","rd")
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqL" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cqO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"cqQ" = (
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
+"cqR" = (
 /turf/closed/wall,
 /area/science/explab)
-"cqQ" = (
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"cqR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+"cqS" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/explab";
 	name = "Experimentation Lab APC";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"cqS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 10
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/machinery/camera{
-	c_tag = "Experimentation Lab";
-	dir = 1;
-	network = list("ss13","rd")
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/explab)
 "cqT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/explab)
 "cqU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
-"cqV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
+/area/science/explab)
+"cqV" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals3"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_decals3"
+	},
+/turf/open/floor/plasteel,
 /area/science/explab)
 "cqW" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28;
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
 "cqX" = (
-/obj/structure/bed/roller,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cqY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cqZ" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cra" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
+"cra" = (
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "crb" = (
@@ -31287,7 +31384,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "crj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -31459,13 +31556,15 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "crF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -31477,6 +31576,10 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "crH" = (
@@ -31486,7 +31589,6 @@
 	name = "Aft Hallway APC";
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -31506,24 +31608,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"crK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
-/area/science/research)
 "crL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "crM" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -31531,63 +31624,135 @@
 /turf/closed/wall/r_wall,
 /area/science/storage)
 "crS" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/science/storage)
-"crT" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
-	req_access_txt = "8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "toxins_blastdoor";
-	name = "biohazard containment shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/storage)
-"crU" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"crT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/science/research)
+"crU" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "crV" = (
-/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "crW" = (
-/obj/structure/closet/l3closet/scientist{
-	pixel_x = -2
+/obj/structure/rack/shelf,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = 11
+	},
+/obj/item/multitool{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/healthanalyzer{
+	pixel_y = -5
+	},
+/obj/item/wrench,
+/obj/item/crowbar,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/camera{
+	c_tag = "Experimentation Lab";
+	dir = 1;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "crX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/vending/wardrobe/science_wardrobe,
-/turf/open/floor/plasteel,
-/area/science/explab)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/item/cigbutt,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "crZ" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin{
 	pixel_x = 2
 	},
 /obj/item/clothing/mask/muzzle,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "csa" = (
@@ -31628,11 +31793,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
@@ -31834,12 +32002,10 @@
 	dir = 8;
 	sortType = 11
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "csH" = (
@@ -31848,6 +32014,9 @@
 	sortType = 23
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "csI" = (
@@ -31858,17 +32027,20 @@
 	dir = 4;
 	req_one_access_txt = "12;5;9"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "csJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -31876,23 +32048,32 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "csL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "csM" = (
@@ -31903,8 +32084,17 @@
 	dir = 8;
 	name = "Aft Emergency Storage"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -31913,73 +32103,88 @@
 	dir = 8;
 	sortType = 14
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"csO" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "csP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	dir = 8;
-	req_one_access_txt = "7;47;29;12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "csQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "csR" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
 	sortType = 12
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "csS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "csU" = (
 /obj/structure/disposalpipe/segment{
@@ -31990,8 +32195,17 @@
 	name = "Research Maintenance";
 	req_one_access_txt = "7;47;29"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -31999,12 +32213,16 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "csW" = (
 /obj/structure/cable/yellow{
@@ -32014,13 +32232,21 @@
 	dir = 8;
 	sortType = 13
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "csX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ctf" = (
@@ -32032,26 +32258,32 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "ctg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cth" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "ctj" = (
@@ -32159,7 +32391,6 @@
 /turf/closed/wall,
 /area/medical/genetics)
 "ctE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -32184,8 +32415,6 @@
 /turf/closed/wall,
 /area/maintenance/aft)
 "ctJ" = (
-/obj/item/storage/toolbox/emergency,
-/obj/structure/closet/firecloset,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -32197,30 +32426,37 @@
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
 "ctM" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Testing Range Maintenance";
-	req_one_access_txt = "7;47;29"
-	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ctN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "ctO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ctP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ctW" = (
@@ -32233,41 +32469,36 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "ctX" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/science/storage)
-"ctY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
+"ctY" = (
 /obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "ctZ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
@@ -32284,30 +32515,47 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "cuc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "cud" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light{
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cuf" = (
 /obj/item/extinguisher,
 /obj/effect/decal/cleanable/cobweb,
@@ -32574,98 +32822,90 @@
 /area/hallway/primary/aft)
 "cuB" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cuC" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/item/wrench,
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cuD" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/space_heater,
+/obj/structure/fluff/railing{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cuE" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cuF" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cuG" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/science/misc_lab/range)
-"cuG" = (
-/turf/open/floor/engine{
-	dir = 9;
-	icon_state = "floor"
-	},
 /area/science/misc_lab/range)
 "cuH" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "floor_whole"
 	},
-/turf/open/floor/plasteel,
-/area/science/misc_lab/range)
+/area/hallway/primary/central)
 "cuI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 5
-	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cuJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cuK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cuS" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/light/small{
+/obj/effect/turf_decal/bot,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cuT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/storage)
-"cuU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
@@ -32676,26 +32916,34 @@
 /area/science/storage)
 "cuW" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light/small{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Toxins Storage";
-	dir = 8;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cuY" = (
-/obj/structure/rack,
-/obj/item/extinguisher,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/mask/gas,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 8;
+	req_access_txt = "12"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/starboard)
 "cuZ" = (
 /turf/closed/wall/r_wall,
 /area/science/circuit)
@@ -32978,28 +33226,23 @@
 	req_access_txt = "29"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cvJ" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -29
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/engine{
-	dir = 9;
-	icon_state = "floor"
-	},
-/area/science/misc_lab/range)
-"cvK" = (
-/obj/machinery/magnetic_module,
-/obj/effect/landmark/blobstart,
-/obj/structure/target_stake,
-/obj/effect/turf_decal/bot{
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/effect/decal/big_gato,
-/turf/open/floor/plasteel{
-	dir = 9
-	},
+/turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cvL" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -33009,11 +33252,17 @@
 /turf/open/floor/plating,
 /area/science/misc_lab/range)
 "cvM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/area/science/research)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "cvN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33024,6 +33273,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cvO" = (
@@ -33033,11 +33288,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -33051,12 +33309,15 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cvW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cvX" = (
@@ -33074,27 +33335,57 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cwa" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Research Division"
+	},
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Research Division Deliveries";
+	req_access_txt = "47"
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "cwb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "cwc" = (
-/obj/machinery/door/airlock/external{
-	name = "Auxiliary Escape Airlock"
+/obj/machinery/light/small{
+	bulb_colour = "#FF3232";
+	color = "#FF3232";
+	dir = 1;
+	light_color = "#FF3232"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "cwd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "cwf" = (
@@ -33356,6 +33647,10 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -28
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cwH" = (
@@ -33383,40 +33678,54 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "cwK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = -29
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine{
+	dir = 9;
+	icon_state = "floor"
+	},
 /area/science/misc_lab/range)
 "cwL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine{
+	dir = 9;
+	icon_state = "floor"
+	},
 /area/science/misc_lab/range)
 "cwM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Research Division Hallway - Mech Bay";
-	dir = 4;
-	network = list("ss13","rd")
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 6
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
 /area/science/research)
 "cwN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cwO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
@@ -33433,11 +33742,11 @@
 /area/science/storage)
 "cwW" = (
 /obj/item/cigbutt,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/machinery/light/small{
+	pixel_x = 12
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
@@ -33446,17 +33755,23 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cwY" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/light/small{
+	pixel_x = -12
 	},
-/obj/machinery/light/small,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/storage)
@@ -33750,6 +34065,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cxE" = (
@@ -33770,42 +34086,48 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "cxH" = (
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cxI" = (
-/obj/machinery/camera{
-	c_tag = "Research Testing Range";
-	dir = 8;
-	network = list("ss13","rd");
-	pixel_y = -22
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cxJ" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cxK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "toxins_blastdoor";
+	name = "biohazard containment shutters"
+	},
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
 	req_access_txt = "8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white/side,
 /area/science/storage)
 "cxL" = (
 /obj/structure/cable/yellow{
@@ -33832,12 +34154,6 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "cxO" = (
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"cxP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "cxQ" = (
@@ -34124,6 +34440,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cyr" = (
@@ -34142,17 +34459,20 @@
 /area/science/robotics/mechbay)
 "cyt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/science/misc_lab/range)
 "cyu" = (
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/science/misc_lab/range)
 "cyv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/camera{
+	c_tag = "Research Division Hallway - Mech Bay";
+	dir = 4;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -34160,14 +34480,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cyx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Research Division Hallway - Central";
+	network = list("ss13","rd");
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -34175,20 +34495,16 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/science/mixing)
-"cyz" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/bombcloset,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "cyA" = (
-/obj/structure/closet/wardrobe/science_white,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/disposal/bin{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyB" = (
@@ -34217,12 +34533,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Toxins - Lab";
-	network = list("ss13","rd")
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyF" = (
@@ -34257,20 +34570,35 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/camera{
+	c_tag = "Toxins - Lab";
+	network = list("ss13","rd");
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cyJ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/light_switch{
-	pixel_y = 28
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -34480,10 +34808,10 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/research{
+	dir = 4;
 	id_tag = "AuxGenetics";
 	name = "Genetics Access";
-	req_access_txt = "9";
-	dir = 4
+	req_access_txt = "9"
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
@@ -34535,6 +34863,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "czj" = (
@@ -34611,41 +34940,65 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "czq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"czr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "toxins_blastdoor";
-	name = "biohazard containment door"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/science/mixing)
-"czs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
-/area/science/mixing)
+/area/science/research)
+"czr" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "toxins_blastdoor";
+	name = "biohazard containment door"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"czs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
 "czt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "toxins_blastdoor";
+	name = "Toxins Shutter Control";
+	pixel_x = -24;
+	req_access_txt = "47"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -10
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "czv" = (
@@ -34676,8 +35029,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "czA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "czB" = (
@@ -34698,6 +35055,9 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;47"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -34734,6 +35094,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -34777,7 +35138,7 @@
 	desc = "A warning sign which reads 'BOMB RANGE";
 	name = "BOMB RANGE"
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/science/mixing)
 "czJ" = (
 /turf/closed/wall,
@@ -35097,9 +35458,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cAm" = (
@@ -35219,45 +35578,76 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cAv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cAw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/door/airlock/research{
-	dir = 8;
-	name = "Toxins Lab";
-	req_access_txt = "8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "toxins_blastdoor";
-	name = "biohazard containment shutters"
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cAx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "toxins_blastdoor";
+	name = "biohazard containment door"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"cAx" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "toxins_blastdoor";
+	name = "biohazard containment shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/door/airlock/research{
+	dir = 8;
+	name = "Toxins Lab";
+	req_access_txt = "8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -35266,6 +35656,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cAz" = (
@@ -35273,6 +35672,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -35284,6 +35689,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cAB" = (
@@ -35294,31 +35705,49 @@
 	dir = 10
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cAC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cAD" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cAE" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/scientist,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -35326,7 +35755,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cAG" = (
@@ -35342,49 +35783,93 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cAH" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "toxins_blastdoor";
+	name = "biohazard containment shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	dir = 4;
+	name = "Toxins Launch Room Access";
+	req_access_txt = "8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
 /area/science/mixing)
 "cAI" = (
-/obj/effect/landmark/blobstart,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"cAK" = (
+/obj/machinery/light{
+	dir = 4
 	},
 /obj/structure/chair/comfy{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cAJ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+"cAL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cAK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cAL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall,
-/area/science/mixing)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cAM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cAN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -35613,28 +36098,30 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cBp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cBq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/poddoor/preopen{
+	dir = 4;
 	id = "toxins_blastdoor";
 	name = "biohazard containment door"
 	},
-/turf/open/floor/plating,
-/area/science/mixing)
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "cBr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -35644,9 +36131,14 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port/aft)
 "cBs" = (
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cBt" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
+"cBu" = (
 /obj/item/assembly/prox_sensor{
 	pixel_x = -4;
 	pixel_y = 1
@@ -35668,7 +36160,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cBu" = (
+"cBv" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/stripes/line{
@@ -35676,7 +36168,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cBv" = (
+"cBw" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/item/screwdriver{
@@ -35686,113 +36178,116 @@
 	dir = 5
 	},
 /obj/item/analyzer,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cBw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cBx" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cBy" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "cBz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cBA" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cBB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/machinery/power/apc{
+	areastring = "/area/science/mixing";
+	dir = 4;
+	name = "Toxins Lab APC";
+	pixel_x = 26
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cBC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/obj/machinery/door/airlock/research{
-	dir = 4;
-	name = "Toxins Launch Room Access";
-	req_access_txt = "8"
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "toxins_blastdoor";
-	name = "biohazard containment shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
 "cBD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
 "cBF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/door/airlock/research{
 	dir = 8;
 	name = "Toxins Launch Room";
 	req_access_txt = "8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBJ" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBK" = (
@@ -36023,22 +36518,35 @@
 /area/science/robotics/lab)
 "cCr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cCs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cCt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "toxins_blastdoor";
+	name = "biohazard containment door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/mixing)
+"cCu" = (
+/obj/structure/closet/wardrobe/science_white,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cCu" = (
+"cCv" = (
 /obj/item/assembly/signaler{
 	pixel_y = 8
 	},
@@ -36058,9 +36566,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -28
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cCv" = (
+"cCw" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
 	},
@@ -36086,7 +36598,7 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cCw" = (
+"cCx" = (
 /obj/item/assembly/timer{
 	pixel_x = 5;
 	pixel_y = 4
@@ -36104,74 +36616,40 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cCx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -28
-	},
-/obj/structure/tank_dispenser,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCy" = (
-/obj/machinery/disposal/bin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"cCA" = (
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
+"cCB" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
+"cCD" = (
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"cCE" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cCz" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cCA" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cCB" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cCD" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cCE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "cCF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCG" = (
@@ -36411,23 +36889,25 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cDh" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/public/glass,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cDi" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
 "cDj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cDk" = (
@@ -37000,9 +37480,7 @@
 /area/science/robotics/lab)
 "cEp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
@@ -39183,6 +39661,12 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cIn" = (
@@ -39595,12 +40079,21 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
 "cJa" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "cJb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -39645,8 +40138,8 @@
 	},
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
-	req_access_txt = "13";
-	dir = 4
+	dir = 4;
+	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -39710,9 +40203,9 @@
 	name = "Research Lab Maintenance";
 	req_one_access_txt = "7;29"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cJn" = (
@@ -40409,18 +40902,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cKD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cKE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -40433,9 +40923,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cKF" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -40475,6 +40962,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cKK" = (
@@ -40696,13 +41186,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "cLi" = (
 /obj/structure/disposalpipe/segment{
@@ -40797,8 +41293,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -40813,17 +41309,20 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"cLu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"cLu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -40875,20 +41374,10 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "cLz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/aft)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/engineering/break_room)
 "cLA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -40909,14 +41398,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "cLC" = (
 /obj/machinery/button/ignition/incinerator/atmos{
@@ -40947,8 +41442,13 @@
 /area/maintenance/disposal/incinerator)
 "cLD" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cLE" = (
@@ -41075,8 +41575,18 @@
 "cLU" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
+"cMa" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cMb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance";
@@ -41108,9 +41618,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cMh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/area/hallway/primary/central)
 "cMi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -41130,11 +41649,11 @@
 	c_tag = "Departure Lounge - Starboard Fore";
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -41382,10 +41901,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cMW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cMX" = (
@@ -41717,23 +42236,23 @@
 "cNO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cNP" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "cNQ" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -41775,10 +42294,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cNT" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cNU" = (
@@ -41865,18 +42380,15 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "cOt" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cOu" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -41891,9 +42403,6 @@
 	dir = 8;
 	name = "Departure Lounge Security Post";
 	req_access_txt = "63"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -41911,14 +42420,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cOw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -41934,9 +42437,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cOx" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -42013,6 +42513,12 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cOJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cOT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -42059,15 +42565,24 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cOY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/wood,
+/area/service/bar)
 "cOZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -42075,11 +42590,11 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -42087,20 +42602,28 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "cPc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/structure/table/plasmaglass,
+/obj/item/clothing/under/misc/stripper,
+/obj/item/reagent_containers/pill/butt_enlargement{
+	pixel_x = 8;
+	pixel_y = 10
 	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/effect/landmark/start/chief_engineer,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/service/bar)
 "cPd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/structure/chair/sofa/corp{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/light/small{
+	bulb_colour = "#FF3232";
+	color = "#FF3232";
+	dir = 4;
+	light_color = "#FF3232"
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "cPf" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -42153,16 +42676,43 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cPs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+"cPm" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/area/service/hydroponics)
+"cPs" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "cPt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -42215,11 +42765,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cPP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/area/hallway/primary/port)
 "cPQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -42255,18 +42812,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cPU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/light/small,
+/mob/living/carbon/monkey/punpun,
+/turf/open/floor/wood,
+/area/service/bar)
 "cPV" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Starboard Aft";
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -42326,7 +42879,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cQo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.4-Escape-4";
 	location = "9.3-Escape-3"
@@ -42335,17 +42887,28 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cQp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.3-Escape-3";
 	location = "9.2-Escape-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cQq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -42441,9 +43004,6 @@
 	},
 /area/science/mixing)
 "cQC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -42453,6 +43013,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cQD" = (
@@ -42488,22 +43049,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cQL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "cQM" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cQN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cQO" = (
@@ -42511,15 +43069,24 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Departure Lounge - Starboard Aft";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cQP" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_x = 32
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "cQR" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xeno_blastdoor";
@@ -43596,8 +44163,8 @@
 	dwidth = 5;
 	height = 7;
 	name = "Cargo Bay";
-	width = 12;
-	shuttle_id = "supply_home"
+	shuttle_id = "supply_home";
+	width = 12
 	},
 /turf/open/space/basic,
 /area/space)
@@ -43634,6 +44201,13 @@
 /area/commons/locker)
 "cVh" = (
 /obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "cVp" = (
@@ -43658,8 +44232,8 @@
 	dwidth = 2;
 	height = 13;
 	name = "port bay 2";
-	width = 5;
-	shuttle_id = "ferry_home"
+	shuttle_id = "ferry_home";
+	width = 5
 	},
 /turf/open/space/basic,
 /area/space)
@@ -43727,9 +44301,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "cWc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/carpet,
 /area/service/bar)
 "cWK" = (
@@ -43864,6 +44439,9 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "cYJ" = (
@@ -43872,8 +44450,8 @@
 	dwidth = 9;
 	height = 25;
 	name = "MetaStation emergency evac bay";
-	width = 29;
-	shuttle_id = "emergency_home"
+	shuttle_id = "emergency_home";
+	width = 29
 	},
 /turf/open/space/basic,
 /area/space)
@@ -44188,11 +44766,11 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port/fore)
 "dbj" = (
-/obj/structure/closet/firecloset{
-	pixel_x = 0
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "dbl" = (
 /obj/structure/easel,
 /turf/open/floor/plating,
@@ -44281,44 +44859,59 @@
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/captain/private)
 "dbG" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/circuit";
-	dir = 1;
-	name = "Circuitry Lab APC";
-	pixel_y = 30
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/structure/table/reinforced,
 /obj/item/multitool,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 12
+	},
+/obj/item/integrated_circuit_printer,
+/obj/item/screwdriver,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "dbH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = "ResearchInt";
-	name = "Research Division";
-	req_one_access_txt = "47"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/research)
-"dbI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	id_tag = "ResearchInt";
 	name = "Research Division";
 	req_one_access_txt = "47"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"dbI" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	id_tag = "ResearchInt";
+	name = "Research Division";
+	req_one_access_txt = "47"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "dbN" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44332,9 +44925,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
+	dir = 4;
 	name = "Solar Maintenance";
-	req_access_txt = "10; 13";
-	dir = 4
+	req_access_txt = "10; 13"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -45241,6 +45834,26 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
 /area/science/xenobiology)
+"deF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "dfw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45525,13 +46138,15 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "dht" = (
-/obj/item/cigbutt,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
 	},
-/obj/structure/trash_pile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/camera{
+	c_tag = "Club - Private Room";
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "dhu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/sign/poster/contraband/random{
@@ -45561,18 +46176,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "dhw" = (
-/obj/structure/closet,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/machinery/light_switch{
+	pixel_x = -26
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/wood,
+/area/service/theater)
 "dhx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -45678,6 +46287,8 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dhR" = (
@@ -45690,14 +46301,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -45761,29 +46366,36 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "diA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard/aft)
-"diB" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
+	icon_state = "1-2"
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
+"diB" = (
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/science/research)
 "diC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -45800,16 +46412,31 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "diD" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Research Break Room";
+	network = list("ss13","rd");
+	pixel_y = 12
+	},
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_y = 30;
+	receive_ore_updates = 1
+	},
+/obj/item/reagent_containers/food/drinks/bottle/gin{
+	pixel_x = 16;
+	pixel_y = 8
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
 /area/science/research)
 "diE" = (
@@ -45886,11 +46513,7 @@
 /obj/item/tank/internals/air,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
-/obj/machinery/space_heater,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "diM" = (
@@ -46062,8 +46685,8 @@
 	height = 15;
 	name = "arrivals";
 	roundstart_template = /datum/map_template/shuttle/arrival/box;
-	width = 7;
-	shuttle_id = "arrivals_stationary"
+	shuttle_id = "arrivals_stationary";
+	width = 7
 	},
 /turf/open/space/basic,
 /area/space)
@@ -46090,9 +46713,31 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "dkr" = (
-/obj/machinery/vending/kink,
-/turf/open/floor/plating,
-/area/commons/toilet/auxiliary)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/commons/storage/art)
 "dkX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46125,7 +46770,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -46136,8 +46780,27 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
+"dlt" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/kitchen/fork{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/science/research)
 "dlA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -46232,14 +46895,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dmL" = (
-/obj/item/toy/dummy,
-/obj/structure/table/wood,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "dmS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -46427,9 +47096,8 @@
 	},
 /area/cargo/storage)
 "dpk" = (
-/obj/item/cigbutt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/carpet/black,
+/area/service/theater)
 "dpm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -46477,19 +47145,22 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "dpF" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/bar";
-	dir = 1;
-	name = "Bar APC";
-	pixel_y = 25
+/obj/machinery/disposal/bin{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
 	},
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "dpG" = (
 /obj/structure/cable/yellow{
@@ -46637,6 +47308,34 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"dsu" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "dsL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -46817,7 +47516,7 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "dve" = (
 /obj/structure/sauna_oven,
@@ -46833,7 +47532,12 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/research_director,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -46876,9 +47580,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dvz" = (
+/obj/machinery/magnetic_module,
+/obj/effect/landmark/blobstart,
+/obj/structure/target_stake,
+/obj/effect/turf_decal/bot{
+	dir = 9
+	},
+/obj/effect/decal/big_gato,
+/turf/open/floor/plasteel{
+	dir = 9
+	},
+/area/science/misc_lab/range)
 "dvD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/sign/poster/official/random,
+/turf/closed/wall,
 /area/service/bar)
 "dvE" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -46973,12 +47689,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dxa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/window/eastright{
 	dir = 1;
 	name = "Kitchen Delivery";
@@ -46988,6 +47698,13 @@
 /turf/open/floor/plasteel,
 /area/service/kitchen)
 "dxh" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -47080,9 +47797,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "dzc" = (
@@ -47132,7 +47846,10 @@
 /turf/open/floor/plasteel/dark/side,
 /area/service/hydroponics/garden)
 "dzQ" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAc" = (
@@ -47170,8 +47887,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	req_access_txt = "13";
-	dir = 4
+	dir = 4;
+	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -47214,11 +47931,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
 "dAX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/service/hydroponics)
+/area/hallway/primary/starboard)
 "dAZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -47244,8 +47964,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
 "dBg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/chair/comfy/black{
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/service/bar)
@@ -47512,9 +48236,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "dCJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -47522,16 +48243,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "dCM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "dCN" = (
@@ -47549,6 +48265,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dCV" = (
@@ -47556,6 +48273,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "dCW" = (
@@ -47564,7 +48284,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/port)
 "dDa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47592,64 +48313,94 @@
 	c_tag = "Kitchen";
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
 "dDo" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dDp" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dDq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "dDr" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "dDs" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "dDu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/science/research)
 "dDv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -47662,6 +48413,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dDz" = (
@@ -47674,6 +48426,12 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -47772,14 +48530,11 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "dFc" = (
-/obj/machinery/door/airlock{
-	name = "Bar Storage";
-	req_access_txt = "25"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/bar)
+/turf/open/floor/plasteel/dark/corner,
+/area/hallway/primary/starboard)
 "dFh" = (
 /obj/machinery/suit_storage_unit/cmo,
 /obj/effect/turf_decal/tile/blue{
@@ -48031,23 +48786,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/teleporter)
-"dLK" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
 "dMm" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
+	dir = 4;
 	name = "Supply Dock Airlock";
-	req_access_txt = "31";
-	dir = 4
+	req_access_txt = "31"
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
@@ -48061,6 +48807,13 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"dNQ" = (
+/obj/structure/scale,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "dOw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48108,6 +48861,16 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
+"dPw" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "dPI" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -48133,11 +48896,12 @@
 /turf/open/floor/plasteel,
 /area/command/gateway)
 "dQg" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;27;37"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dRb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48193,6 +48957,18 @@
 	pixel_x = -26;
 	req_access_txt = "28"
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
 "dSu" = (
@@ -48220,6 +48996,12 @@
 /area/engineering/main)
 "dSO" = (
 /mob/living/simple_animal/pet/dog/corgi/Ian,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
 "dSR" = (
@@ -48373,6 +49155,12 @@
 /obj/structure/window/plasma/reinforced,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"dXa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "dXi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -48391,27 +49179,29 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"dXM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+"dXY" = (
+/obj/structure/trash_pile,
+/obj/structure/fluff/railing{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/service/bar)
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "dYf" = (
 /turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
 "dYt" = (
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/structure/table,
+/obj/machinery/plantgenes{
+	pixel_y = 6
 	},
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "dYu" = (
@@ -48431,7 +49221,6 @@
 	id = "kitchen";
 	name = "Serving Hatch"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/reagent_containers/food/snacks/pie/cream,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -48568,8 +49357,24 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
+"ebs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/science/circuit)
 "ecl" = (
 /obj/structure/window/reinforced,
 /obj/machinery/light{
@@ -48580,6 +49385,21 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/commons/fitness/recreation)
+"ecA" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "edG" = (
 /turf/closed/wall,
 /area/commons/cryopod)
@@ -48624,15 +49444,17 @@
 /turf/open/floor/plasteel/dark,
 /area/command/teleporter)
 "efP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -48730,6 +49552,12 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solars/port/aft)
+"ehq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ehF" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/tile/yellow{
@@ -48778,9 +49606,6 @@
 	dir = 8;
 	name = "Engineering Foyer";
 	req_one_access_txt = "32;19"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -48887,22 +49712,40 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "elo" = (
-/obj/structure/sign/plaques/deempisi{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
+"elv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ely" = (
 /obj/machinery/computer/card/minor/rd{
 	dir = 4
@@ -48933,26 +49776,30 @@
 "emj" = (
 /turf/open/floor/plasteel/yellowsiding,
 /area/commons/fitness/recreation)
-"emo" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/wood,
-/area/service/bar)
+"emu" = (
+/obj/structure/table/reinforced,
+/obj/item/multitool,
+/obj/item/integrated_circuit_printer,
+/obj/item/screwdriver,
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "emB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "emC" = (
 /obj/structure/window/reinforced{
@@ -48962,25 +49809,19 @@
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
 "emH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
 "eof" = (
 /turf/closed/wall,
 /area/commons/toilet/restrooms)
 "eoK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "eoN" = (
@@ -48989,20 +49830,18 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "eqq" = (
-/obj/item/screwdriver,
-/obj/structure/table/reinforced,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/machinery/computer/security/telescreen/circuitry{
+	pixel_y = 30
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "eqG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
@@ -49012,10 +49851,51 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"erp" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"erw" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_y = 6
+	},
+/obj/item/gps{
+	gpstag = "RD0";
+	pixel_x = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "erD" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "erE" = (
@@ -49025,6 +49905,14 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
+"erX" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/trash_pile,
+/obj/item/book/manual/fatty_chems,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "esj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -49036,7 +49924,7 @@
 	id_tag = "Toilet4";
 	name = "Unit 4"
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "esC" = (
 /obj/structure/cable/yellow{
@@ -49105,35 +49993,43 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
 "etM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "AuxToilet3";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/effect/landmark/blobstart,
-/obj/structure/toilet{
-	dir = 8
+/obj/machinery/space_heater,
+/obj/structure/fluff/railing{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/commons/toilet/auxiliary)
+/area/maintenance/port)
 "euh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"eum" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;35;47"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "evV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair/stool/brass,
-/turf/open/floor/wood,
+/obj/structure/table/wood/fancy/red,
+/obj/item/reagent_containers/food/snacks/bbqribs{
+	pixel_y = -2
+	},
+/obj/item/ashtray{
+	name = "candle holder";
+	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet,
 /area/service/bar)
 "ewx" = (
 /obj/effect/turf_decal/stripes/line{
@@ -49332,17 +50228,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
 "eAH" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder{
+	pixel_x = -5;
+	pixel_y = 7
 	},
-/obj,
-/obj,
-/obj,
-/obj,
-/turf/open/floor/plasteel,
-/area/commons/storage/art)
+/turf/open/floor/wood,
+/area/service/bar)
 "eAK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
@@ -49384,12 +50276,17 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "eBu" = (
-/obj/structure/window/reinforced{
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "eBD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
@@ -49429,7 +50326,16 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "eCf" = (
-/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/closet/secure_closet/bar{
+	req_access_txt = "25"
+	},
+/obj/item/book/manual/blubbery_bartender,
+/obj/item/vending_refill/cigarette,
+/obj/item/wrench,
+/obj/item/stack/cable_coil/random,
+/obj/item/gun/ballistic/revolver/doublebarrel,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
 /turf/open/floor/wood,
 /area/service/bar)
 "eCq" = (
@@ -49546,11 +50452,15 @@
 /turf/closed/wall/r_wall,
 /area/command/gateway)
 "eEe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	name = "Bar Storage";
+	req_access_txt = "25"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/turf/open/floor/wood,
+/area/service/bar)
 "eEy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -49752,9 +50662,6 @@
 	},
 /area/engineering/main)
 "eMh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/hallway/primary/central";
 	dir = 1;
@@ -49766,6 +50673,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -49784,18 +50694,6 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/main)
-"eNY" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/chair/sofa/right{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/service/bar)
 "eOa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -49855,28 +50753,29 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "eOP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"ePg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
+/turf/open/floor/plasteel{
 	dir = 4;
-	name = "Auxiliary Bathrooms"
+	icon_state = "floor_trim"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/area/science/research)
 "ePh" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 26
@@ -49885,7 +50784,7 @@
 /area/command/heads_quarters/hop)
 "ePj" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "ePw" = (
 /obj/machinery/button/door{
@@ -49978,8 +50877,10 @@
 /turf/open/floor/wood,
 /area/service/library)
 "eSb" = (
-/obj/structure/sign/carts,
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/entry)
 "eSp" = (
 /obj/structure/cable/yellow{
@@ -49992,15 +50893,6 @@
 	dir = 4
 	},
 /area/service/hydroponics/garden)
-"eSC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "eSK" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/firealarm{
@@ -50019,20 +50911,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/command/storage/eva)
-"eSQ" = (
-/obj/machinery/light_switch{
-	pixel_x = 8;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood,
-/area/service/bar)
 "eTe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50054,22 +50932,22 @@
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "eTE" = (
-/obj/machinery/light/small{
+/obj/structure/rack/shelf,
+/obj/item/reagent_containers/glass/bucket/wood{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/item/clothing/mask/horsehead,
-/obj/structure/table/wood,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
+/obj/item/mop,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/item/clothing/mask/cigarette/pipe,
-/obj/item/clothing/mask/fakemoustache,
-/turf/open/floor/wood,
-/area/service/theater)
+/area/hallway/secondary/service)
 "eTH" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -50121,6 +50999,9 @@
 	pixel_x = 5;
 	pixel_y = -5;
 	req_access_txt = "47"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -50177,7 +51058,7 @@
 	pixel_y = 32
 	},
 /obj/structure/scale,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "eVL" = (
 /obj/structure/window/reinforced,
@@ -50234,14 +51115,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Research Director's Desk";
-	departmentType = 5;
-	name = "Research Director RC";
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 8
 	},
@@ -50268,14 +51141,22 @@
 /area/command/heads_quarters/captain/private)
 "eXX" = (
 /obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/rag{
+	pixel_y = 3
+	},
 /obj/item/storage/box/matches{
-	pixel_y = 5
+	pixel_y = -6
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/item/lighter{
+	pixel_x = 10;
+	pixel_y = -12
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/service/bar)
 "eYD" = (
 /obj/structure/cable{
@@ -50335,6 +51216,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
+"faz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "faG" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -50348,17 +51241,36 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "faU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"fbe" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/science/research)
 "fbn" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -50380,18 +51292,18 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "fbJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/machinery/power/apc{
+	areastring = "/area/hydroponics";
+	name = "Hydroponics APC";
+	pixel_y = -28
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -50412,6 +51324,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
+"fcj" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "fcl" = (
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
@@ -50433,30 +51355,34 @@
 	pixel_x = 2;
 	pixel_y = -1
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/science/mixing";
-	dir = 4;
-	name = "Toxins Lab APC";
-	pixel_x = 26
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"fcU" = (
-/obj/structure/disposalpipe/segment{
+"fcO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"fcU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -50484,13 +51410,43 @@
 	dir = 8
 	},
 /area/hallway/primary/central)
+"fdm" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "fdE" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
 /area/service/bar)
+"fef" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/sign/map/right{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-right-MS";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "fem" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -50503,18 +51459,44 @@
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/hop)
 "feJ" = (
-/obj/machinery/disposal/bin{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
 	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood,
-/area/service/bar)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
 "feU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_y = 30
+	},
+/obj/structure/table/wood,
+/obj/item/phone{
+	desc = "Who can it be now?";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "ffs" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -50550,18 +51532,19 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "ffS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "fgj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -50573,7 +51556,7 @@
 	c_tag = "Restrooms";
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "fgv" = (
 /obj/machinery/door/firedoor,
@@ -50664,6 +51647,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/commons/dorms)
+"fjm" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/explab)
+"fjz" = (
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "fkj" = (
 /obj/item/folder/blue,
 /obj/structure/table/glass,
@@ -50677,17 +51674,16 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
 "fkx" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
 	},
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/machinery/vending/clothing,
 /turf/open/floor/wood,
 /area/service/bar)
 "fkF" = (
 /obj/item/book/manual/fatty_chems,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "flE" = (
@@ -50836,15 +51832,25 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
 "fse" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
+/turf/open/floor/engine,
+/area/science/explab)
+"fsf" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "steel_decals5"
+	},
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_trim"
+	},
+/area/hallway/primary/central)
 "fsi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -50930,15 +51936,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fwb" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood,
-/area/service/bar)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fwd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -51041,19 +52043,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
 "fyZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/firealarm{
 	pixel_y = 29
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/structure/closet/crate/hydroponics,
-/obj/item/shovel/spade,
-/obj/item/wrench,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/cultivator,
-/obj/item/wirecutters,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "fzt" = (
@@ -51088,6 +52081,21 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
+"fAn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "fAA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -51114,25 +52122,19 @@
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "fCx" = (
-/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "fCR" = (
-/obj/machinery/door/airlock/maintenance{
-	dir = 8;
-	req_one_access_txt = "12;25;46"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/item/beacon,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "fCZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
@@ -51157,8 +52159,14 @@
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -51207,17 +52215,6 @@
 "fEX" = (
 /turf/open/floor/wood,
 /area/service/library)
-"fFa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/kitchen)
 "fFq" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -51241,18 +52238,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
-"fFM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+"fFA" = (
+/obj/structure/sign/warning/vacuum{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"fFM" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/white,
-/area/science/circuit)
+/area/science/research)
 "fFR" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51276,7 +52294,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "fGC" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "fHg" = (
@@ -51402,6 +52423,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/office)
+"fLC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "fLL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -51415,14 +52446,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"fLM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/kitchen)
 "fLW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -51434,6 +52457,15 @@
 	},
 /turf/open/floor/plating,
 /area/command/bridge)
+"fLY" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "fMm" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
@@ -51469,7 +52501,15 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "fMW" = (
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "fNf" = (
@@ -51490,7 +52530,15 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "fNk" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/structure/rack/shelf,
+/obj/item/wrench,
+/obj/item/wirecutters,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/clothing/suit/apron,
+/obj/item/crowbar,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "fNy" = (
@@ -51608,6 +52656,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/commons/fitness/recreation)
+"fRJ" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/camera{
+	c_tag = "Toxins Storage";
+	dir = 8;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/plasteel,
+/area/science/storage)
 "fSe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
@@ -51766,12 +52824,23 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "fWz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/landmark/start/mime,
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "fWJ" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -51784,13 +52853,6 @@
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall,
 /area/service/hydroponics)
-"fXa" = (
-/obj/structure/dresser,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/service/theater)
 "fXZ" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -51799,19 +52861,16 @@
 /turf/open/space,
 /area/solars/port/aft)
 "fYa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/green{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/machinery/button/door{
+	id = "kitchenhydro";
+	name = "Service Shutter Control";
+	pixel_x = -24;
+	pixel_y = -24;
+	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -51824,9 +52883,14 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "fZR" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -51908,8 +52972,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/warning/biohazard{
-	pixel_y = 32
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	departmentType = 5;
+	name = "Research Director RC";
+	pixel_y = 30;
+	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/command/heads_quarters/rd)
@@ -52073,19 +53142,14 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "ggA" = (
-/obj/machinery/camera{
-	c_tag = "Club - Starboard";
-	dir = 8
-	},
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/sign/poster/random{
-	pixel_x = 32
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/service/bar)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "ggU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot,
@@ -52096,11 +53160,25 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "ghl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white/side,
+/area/commons/storage/art)
 "ghn" = (
 /obj/machinery/computer/card{
 	dir = 1
@@ -52110,6 +53188,18 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"ghF" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ghM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/yellow{
@@ -52117,6 +53207,10 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port)
+"ghO" = (
+/obj/structure/fluff/railing,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ghS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -52132,13 +53226,22 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	sortType = 20
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "giv" = (
 /obj/structure/disposalpipe/segment{
@@ -52147,9 +53250,25 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
+"giL" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "giS" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/service/bar)
@@ -52158,7 +53277,7 @@
 	name = "Unisex Showers"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "gjr" = (
 /obj/structure/cable/yellow{
@@ -52286,8 +53405,12 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "gnZ" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -52312,10 +53435,16 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "gpH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/spawner/lootdrop/gambling{
+	pixel_y = 7
 	},
-/turf/open/floor/carpet,
+/obj/item/ashtray{
+	name = "candle holder";
+	pixel_x = 16;
+	pixel_y = 2
+	},
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/wood,
 /area/service/bar)
 "gqh" = (
 /obj/machinery/firealarm{
@@ -52348,19 +53477,13 @@
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
 "gra" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/catwalk_floor,
+/obj/structure/rack,
+/obj/item/extinguisher,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/mask/gas,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "grh" = (
 /obj/item/clothing/mask/gas,
@@ -52389,21 +53512,21 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "gst" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-8"
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
-"gsy" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
 "gsT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52443,6 +53566,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"gtU" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/chair/beanbag/black{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/science/research)
 "gua" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52506,6 +53644,9 @@
 "gvV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "gvY" = (
@@ -52646,15 +53787,16 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "gzG" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
+	dir = 4;
 	id = "ceprivacy";
 	name = "privacy shutter"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "gzN" = (
@@ -52747,9 +53889,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/door/airlock/external{
+	dir = 4;
 	name = "Atmospherics External Airlock";
-	req_access_txt = "24";
-	dir = 4
+	req_access_txt = "24"
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -52759,14 +53901,11 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"gCe" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "gCt" = (
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -52777,6 +53916,16 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/snacks/grown/pumpkin{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/carrot,
+/obj/item/seeds/wheat,
+/obj/item/seeds/sugarcane,
+/obj/item/seeds/potato,
+/obj/item/seeds/apple,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "gCx" = (
@@ -52840,16 +53989,20 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
 "gFi" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/easel,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "kitchenwindow";
-	name = "kitchen shutters"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/service/kitchen)
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
+/area/commons/storage/art)
 "gFm" = (
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
@@ -52906,14 +54059,9 @@
 /turf/open/floor/plasteel,
 /area/commons/dorms)
 "gGc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port)
+/obj/machinery/vending/mealdor,
+/turf/open/floor/wood,
+/area/service/library)
 "gGH" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -52922,9 +54070,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "gGT" = (
-/obj/effect/landmark/start/scientist,
-/obj/structure/chair/office/light{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -52932,8 +54079,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "gHk" = (
@@ -52965,6 +54114,19 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"gII" = (
+/obj/structure/closet,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/space)
 "gJm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -53051,6 +54213,10 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "gMz" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenhydro";
+	name = "Service Shutter"
+	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/service/hydroponics)
@@ -53077,8 +54243,20 @@
 /area/service/chapel/office)
 "gNe" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/maintenance/aft";
+	name = "Aft Maintenance APC";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
+"gNs" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "gNH" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -53199,8 +54377,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
 "gRD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/service/bar)
@@ -53233,9 +54414,9 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "gRS" = (
-/obj/structure/table/reinforced,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_circuit_printer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "gSK" = (
@@ -53252,9 +54433,13 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
 "gTs" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/arrows,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "gTN" = (
@@ -53277,8 +54462,31 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"gVf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/closet/bombcloset,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "gVv" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -53317,12 +54525,24 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "gWH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 2;
+	sortType = 19
 	},
-/mob/living/carbon/monkey/punpun,
-/turf/open/floor/wood,
-/area/service/bar)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
 "gXt" = (
 /obj/machinery/camera{
 	c_tag = "Fitness Room - Fore"
@@ -53463,7 +54683,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "hci" = (
 /obj/structure/cable{
@@ -53481,6 +54701,29 @@
 "hcC" = (
 /turf/closed/wall,
 /area/medical/treatment_center)
+"hcX" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/kitchen)
 "hdk" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -53572,18 +54815,20 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "hfE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -53607,15 +54852,13 @@
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
 "hgV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/table/wood/fancy/red,
+/obj/item/reagent_containers/food/snacks/burger/fish{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/chair/sofachair,
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/carpet,
 /area/service/bar)
 "hhA" = (
 /turf/open/floor/plasteel,
@@ -53722,7 +54965,7 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
 "hla" = (
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "hlh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -53808,6 +55051,29 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/teleporter)
+"hnj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"hno" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/science/explab)
 "hny" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -53845,6 +55111,26 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"hoL" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "toxins_blastdoor";
+	name = "biohazard containment shutters"
+	},
+/obj/machinery/door/airlock/research{
+	name = "Toxins Storage";
+	req_access_txt = "8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "hpe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53882,15 +55168,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
-"hpl" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
 "hpr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -53928,13 +55205,22 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "hpC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24;
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "hpG" = (
@@ -53971,14 +55257,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
 /area/service/bar)
 "hrn" = (
 /obj/structure/table/reinforced,
@@ -53992,18 +55276,22 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "hrB" = (
-/obj/structure/table/wood,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/gun/ballistic/revolver/doublebarrel,
-/obj/machinery/camera{
-	c_tag = "Bar - Backroom"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
 	},
-/obj/structure/sink/kitchen{
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/service/bar)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
 "hsi" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole,
@@ -54046,7 +55334,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "hsG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -54084,18 +55372,34 @@
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "htO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/item/paper_bin/construction,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/commons/storage/art)
 "htZ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"hut" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "huJ" = (
 /obj/structure/table/wood,
 /obj/structure/window/reinforced,
@@ -54110,11 +55414,15 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "huP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/door/airlock/public/glass{
+	dir = 8;
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/service/bar)
 "huS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -54128,16 +55436,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
-"hvn" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+"hvi" = (
+/obj/machinery/camera{
+	c_tag = "Research Testing Range";
+	dir = 8;
+	network = list("ss13","rd");
+	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/service/bar)
+/turf/open/floor/plating,
+/area/science/misc_lab/range)
 "hvy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -54175,6 +55482,12 @@
 	},
 /turf/closed/wall,
 /area/engineering/main)
+"hwx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "hwM" = (
 /obj/item/candle,
 /obj/machinery/light_switch{
@@ -54239,9 +55552,21 @@
 /turf/open/floor/plasteel,
 /area/commons/dorms)
 "hyy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/commons/toilet/auxiliary)
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side,
+/area/commons/storage/art)
 "hyP" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -54286,9 +55611,6 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
 "hzH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -54301,6 +55623,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
@@ -54318,12 +55644,29 @@
 /area/commons/fitness/recreation)
 "hzS" = (
 /obj/machinery/door/poddoor{
+	dir = 4;
 	id = "Secure Storage";
-	name = "Secure Storage";
-	dir = 4
+	name = "Secure Storage"
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"hzY" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/bar)
 "hAr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -54340,14 +55683,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "hAL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
 /area/service/bar)
 "hAM" = (
 /obj/machinery/airalarm{
@@ -54405,7 +55746,7 @@
 /area/commons/vacant_room/office)
 "hCt" = (
 /obj/machinery/gibber,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "hCA" = (
 /obj/structure/chair/sofa/left{
@@ -54417,15 +55758,9 @@
 /turf/open/floor/carpet/blue,
 /area/medical/patients_rooms/room_a)
 "hCH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -54434,7 +55769,11 @@
 	c_tag = "Kitchen - Coldroom";
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "hCU" = (
 /obj/structure/cable/yellow{
@@ -54480,6 +55819,15 @@
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
+"hDW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "hEm" = (
 /obj/item/taperecorder,
 /obj/item/cartridge/lawyer,
@@ -54544,7 +55892,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "hFt" = (
@@ -54602,6 +55949,15 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"hIc" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "hIg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
@@ -54619,12 +55975,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hIO" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/commons/storage/art)
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hJe" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -54653,14 +56015,17 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
 "hJC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/item/reagent_containers/food/drinks/ale{
+	pixel_x = 6;
+	pixel_y = 7
 	},
-/obj/structure/chair/sofa/right{
-	dir = 8
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = -7;
+	pixel_y = 7
 	},
 /turf/open/floor/wood,
 /area/service/bar)
@@ -54682,17 +56047,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
-"hKk" = (
-/obj/structure/table/wood,
-/obj/item/ashtray{
-	name = "candle holder"
-	},
-/obj/item/candle{
-	pixel_x = 1;
-	pixel_y = 7
-	},
-/turf/open/floor/wood,
-/area/service/bar)
 "hKm" = (
 /obj/item/folder/white{
 	pixel_x = 4;
@@ -54804,7 +56158,7 @@
 /obj/structure/urinal{
 	pixel_y = 29
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "hMN" = (
 /turf/open/floor/plasteel,
@@ -54812,6 +56166,15 @@
 "hMQ" = (
 /turf/closed/wall/r_wall,
 /area/command/bridge)
+"hNk" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "hNx" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -54845,14 +56208,11 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "hNP" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/sign/poster/random{
+	pixel_x = -32
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/chair/stool/bar/bronze,
-/turf/open/floor/carpet,
+/obj/structure/chair/sofa/right,
+/turf/open/floor/wood,
 /area/service/bar)
 "hNW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -54923,23 +56283,16 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
 "hPI" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command{
-	dir = 8;
-	name = "Head of Personnel";
-	req_access_txt = "57"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/item/cigbutt,
+/obj/structure/chair/sofa/left{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/turf/open/floor/wood,
-/area/command/heads_quarters/hop)
+/turf/open/floor/carpet/purple,
+/area/science/research)
 "hQl" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -55107,8 +56460,25 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "hVs" = (
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/obj/structure/table,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/commons/storage/art)
 "hVw" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -55139,6 +56509,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
+"hXp" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "hXr" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -55338,15 +56723,40 @@
 	},
 /area/service/chapel/main)
 "iaA" = (
-/turf/open/floor/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
 /area/service/bar)
 "iaE" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/structure/sign/barsign{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/bar)
 "ibn" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -55396,7 +56806,7 @@
 /obj/structure/urinal{
 	pixel_y = 29
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "idz" = (
 /obj/effect/turf_decal/tile/blue{
@@ -55407,6 +56817,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ieo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "ieA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -55425,6 +56841,18 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"ieX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "steel_decals5"
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "floor_trim"
+	},
+/area/hallway/primary/central)
 "ifs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -55514,22 +56942,36 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "iiE" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "area/crew_quarters/theatre";
-	name = "Theatre APC";
-	pixel_y = -29
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/structure/cable/yellow,
-/obj/structure/closet/crate/wooden/toy,
-/obj/machinery/light/small{
-	pixel_x = -8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/cigbutt/roach{
+	pixel_x = -10;
+	pixel_y = 15
+	},
+/obj/item/clothing/mask/cigarette/rollie/cannabis{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/ashtray{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "iiG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55547,11 +56989,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
-"ijm" = (
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/kitchen)
 "ijq" = (
 /turf/open/space,
 /area/maintenance/solars/starboard/fore)
@@ -55567,10 +57004,12 @@
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
 "ijI" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/arrows{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -55648,7 +57087,22 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -55692,7 +57146,8 @@
 /turf/open/space,
 /area/solars/starboard/fore)
 "ioI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /obj/machinery/door/airlock/research/glass{
@@ -55700,8 +57155,15 @@
 	name = "Circuitry Lab";
 	req_access_txt = "47"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/science/circuit)
 "iph" = (
 /obj/item/stack/rods{
@@ -55757,21 +57219,21 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "iqv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	dir = 4;
-	name = "Hydroponics Backroom";
-	req_access_txt = "35"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Hydroponics Backroom";
+	req_access_txt = "35"
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -55819,21 +57281,44 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
+"irO" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "rdprivacy";
+	name = "privacy shutter"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/command/heads_quarters/rd)
 "irY" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
+"isX" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "itk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -55851,16 +57336,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/engineering/atmos)
-"itL" = (
-/obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
+"itM" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "itP" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -55921,15 +57400,22 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "iuF" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "iuW" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -55958,6 +57444,12 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"ivR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "iwd" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/airalarm{
@@ -56113,9 +57605,6 @@
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
 "izu" = (
-/obj/machinery/autolathe{
-	name = "public autolathe"
-	},
 /obj/machinery/door/window/eastright{
 	dir = 2;
 	name = "Research and Development Desk";
@@ -56126,17 +57615,10 @@
 	id = "research_shutters";
 	name = "research shutters"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/autolathe{
+	name = "public autolathe"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/science/lab)
 "izA" = (
 /obj/structure/chair/comfy/black{
@@ -56166,10 +57648,15 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "iAD" = (
-/obj/machinery/newscaster{
-	pixel_x = -30
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/science/research)
 "iAK" = (
 /obj/structure/window/reinforced,
@@ -56190,7 +57677,6 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "iAR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -56203,6 +57689,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
@@ -56253,7 +57742,7 @@
 /area/engineering/atmos)
 "iEi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "iEy" = (
 /obj/structure/cable/yellow{
@@ -56509,17 +57998,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/command/nuke_storage)
 "iIJ" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/obj/machinery/vending/gato,
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "iIW" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -56615,9 +58100,6 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "iMH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -56625,6 +58107,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "iMN" = (
@@ -56681,7 +58164,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "iOZ" = (
 /obj/machinery/door/window{
@@ -56728,6 +58211,19 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
+"iRz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"iSg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/freezer,
+/area/service/kitchen)
 "iSt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -56741,20 +58237,32 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "iSE" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/service/kitchen)
 "iSO" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/structure/closet/crate/hydroponics,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/item/clothing/accessory/armband/hydro,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "iTm" = (
@@ -56764,20 +58272,17 @@
 	name = "Research Division APC";
 	pixel_y = 25
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/machinery/camera{
 	c_tag = "Research Division - Airlock";
 	network = list("ss13","rd")
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/research)
 "iTy" = (
 /obj/structure/disposalpipe/segment,
@@ -56834,18 +58339,31 @@
 	},
 /area/cargo/office)
 "iUN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/medium_gato,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "iUY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/bar,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/bar{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
+"iVb" = (
+/obj/structure/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iVr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/requests_console{
@@ -56907,25 +58425,27 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "iYv" = (
-/obj/machinery/biogenerator,
-/obj/machinery/light_switch{
-	pixel_x = 26
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 14;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "iYz" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/structure/chair/stool/bar/bronze,
+/obj/item/clothing/head/that{
+	pixel_x = -1;
+	pixel_y = 2
 	},
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/turf/open/floor/carpet,
+/area/service/bar)
 "iYH" = (
 /obj/item/stack/cable_coil,
 /obj/structure/lattice/catwalk,
@@ -56935,20 +58455,36 @@
 /turf/closed/wall/r_wall,
 /area/engineering/break_room)
 "iZl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
+"iZm" = (
+/obj/machinery/light_switch{
+	pixel_x = 8;
+	pixel_y = -22
+	},
+/obj/machinery/camera{
+	c_tag = "Club - Starboard";
+	dir = 10
+	},
+/turf/open/floor/carpet,
+/area/service/bar)
 "iZM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = 32
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -56965,6 +58501,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
+"jbd" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "jbv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -57006,32 +58552,32 @@
 /turf/open/floor/plasteel/dark,
 /area/command/teleporter)
 "jbH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/chair/beanbag/green{
+	dir = 8;
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "jbZ" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
+/obj/machinery/camera{
+	c_tag = "Bar - Backroom";
+	pixel_y = 12
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/easel,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXtwentythree,
-/turf/open/floor/plasteel,
-/area/commons/storage/art)
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/wood,
+/area/service/bar)
 "jcc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -57204,6 +58750,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/hop)
+"jgP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/command/heads_quarters/rd)
 "jho" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/warning/securearea,
@@ -57219,19 +58776,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jhw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/service/bar)
 "jhV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -57240,7 +58784,11 @@
 /turf/open/floor/plating,
 /area/command/gateway)
 "jig" = (
-/turf/open/floor/plasteel/showroomfloor,
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Evil Pete"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "jik" = (
 /obj/structure/disposalpipe/segment{
@@ -57253,6 +58801,21 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/cargo/qm)
+"jin" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "jit" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -57260,19 +58823,13 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
 "jiG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "rdprivacy";
 	name = "privacy shutter"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
@@ -57311,17 +58868,14 @@
 /area/maintenance/port/aft)
 "jjm" = (
 /obj/effect/landmark/start/cook,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "jjF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/fluff/railing{
+	dir = 1
 	},
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "jjI" = (
 /obj/machinery/door/airlock/maintenance{
@@ -57341,9 +58895,18 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "jkm" = (
-/obj/effect/spawner/structure/window,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/service/bar)
+"jkX" = (
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Escape Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/commons/storage/art)
+/area/maintenance/aft)
 "jlc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57358,8 +58921,15 @@
 /area/service/chapel/office)
 "jmq" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -57461,10 +59031,11 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "joP" = (
-/obj/structure/closet/secure_closet/bar{
+/obj/machinery/door/window/southleft{
+	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
-/obj/item/book/manual/blubbery_bartender,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/wood,
 /area/service/bar)
 "joS" = (
@@ -57519,16 +59090,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "jpr" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/service/bar)
 "jra" = (
 /obj/structure/cable/yellow{
@@ -57583,8 +59149,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "jsx" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/wood,
 /area/service/bar)
 "jtn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -57628,7 +59194,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "jtX" = (
@@ -57643,14 +59209,12 @@
 /turf/open/floor/wood,
 /area/service/library)
 "jug" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchenhydro";
-	name = "Service Shutter"
-	},
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
 	req_one_access_txt = "35;28"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -57667,10 +59231,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
-"jvn" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/service/bar)
 "jvP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -57727,7 +59287,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -57845,6 +59405,10 @@
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_x = 30
 	},
+/obj/item/stack/sheet/metal/ten,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "jyQ" = (
@@ -57886,6 +59450,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"jyY" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera{
+	c_tag = "Arrivals - Aft Arm - Far";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jzm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -57949,22 +59521,20 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "jAS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
 	},
-/obj/item/wrench,
-/obj/item/stack/sheet/glass{
-	amount = 30
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/item/stack/sheet/metal{
-	amount = 30
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/structure/closet,
-/obj/item/vending_refill/cigarette,
-/turf/open/floor/wood,
-/area/service/bar)
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
 "jBe" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -57992,12 +59562,6 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
-"jBu" = (
-/obj/structure/chair/sofa{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/service/bar)
 "jBD" = (
 /obj/machinery/power/apc{
 	areastring = "/area/quartermaster/miningoffice";
@@ -58038,6 +59602,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
+"jCO" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "jDx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -58110,13 +59687,8 @@
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
 "jGA" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light,
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood,
+/obj/machinery/door/firedoor,
+/turf/open/floor/carpet,
 /area/service/bar)
 "jIg" = (
 /obj/structure/sign/directions/evac,
@@ -58127,7 +59699,15 @@
 	pixel_y = -8
 	},
 /turf/closed/wall,
-/area/commons/storage/art)
+/area/service/bar)
+"jIy" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shuttersbr";
+	name = "Research Break Room Shutters"
+	},
+/turf/open/floor/plating,
+/area/science/research)
 "jIF" = (
 /obj/structure/chair/stool,
 /obj/machinery/light/small{
@@ -58135,18 +59715,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jIS" = (
-/obj/machinery/vending/autodrobe,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_x = -8;
-	pixel_y = 12
-	},
-/turf/open/floor/wood,
-/area/service/theater)
 "jJw" = (
 /obj/structure/sign/map/left{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -58177,26 +59745,26 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "jKl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/commons/storage/art)
 "jKK" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	req_access_txt = "13";
-	dir = 4
+	dir = 4;
+	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -58230,12 +59798,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
-"jLE" = (
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/bar)
 "jLF" = (
 /obj/machinery/door/airlock{
 	name = "Cryogenics"
@@ -58267,21 +59829,9 @@
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "jLY" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/obj/structure/trash_pile,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "jMq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/secequipment,
@@ -58380,6 +59930,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
+"jNy" = (
+/obj/structure/closet/crate/hydroponics,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "jNA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/structure/window/reinforced,
@@ -58398,18 +59953,23 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "jPl" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/effect/turf_decal/tile/bar,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/bar{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "jPn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -58476,13 +60036,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/commons/cryopod)
-"jQR" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
 "jQT" = (
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
@@ -58587,15 +60140,18 @@
 /turf/closed/wall,
 /area/service/chapel/main)
 "jSe" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/button/door{
+	id = "hop";
+	name = "Privacy Shutters Control";
+	pixel_x = -24;
+	pixel_y = -6;
+	req_access_txt = "28"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = -25;
+	pixel_y = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
 "jSv" = (
@@ -58678,12 +60234,12 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "jUo" = (
-/obj/effect/turf_decal/bot,
 /obj/structure/railing,
+/obj/effect/turf_decal/bot,
 /obj/vehicle/ridden/grocery_cart{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "jUp" = (
 /obj/machinery/door/window/northleft{
@@ -58911,13 +60467,21 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	dir = 8
+	dir = 8;
+	name = "Mining Dock Airlock"
 	},
 /turf/open/floor/plating,
 /area/cargo/miningoffice)
 "kfu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "kfM" = (
@@ -58985,6 +60549,13 @@
 	dir = 5
 	},
 /area/service/kitchen)
+"kgF" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "kgN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59084,14 +60655,19 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
 "kiL" = (
-/obj/machinery/computer/slot_machine{
-	pixel_y = 2
+/obj/machinery/computer/security/telescreen{
+	dir = 8;
+	name = "Telecomms Camera Monitor";
+	network = list("tcomms");
+	pixel_x = 26
 	},
-/obj/structure/sign/barsign{
-	pixel_y = 32
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 6
 	},
-/turf/open/floor/carpet,
-/area/service/bar)
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "kiW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59102,9 +60678,9 @@
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "kje" = (
-/obj/structure/sign/departments/restroom,
-/turf/closed/wall,
-/area/commons/toilet/auxiliary)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/commons/storage/art)
 "kjA" = (
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
@@ -59160,6 +60736,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"kly" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
 "klE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -59173,6 +60758,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
+"klH" = (
+/obj/item/reagent_containers/food/snacks/burger/soylent,
+/obj/item/ashtray{
+	pixel_x = 9
+	},
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/carpet/purple,
+/area/science/research)
 "klX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -59180,18 +60773,51 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "kmr" = (
-/obj/effect/landmark/start/botanist,
-/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
+"kmN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_decals3"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals3"
+	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "kmP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	dir = 8;
-	name = "Bar"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/service/bar)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/rack/shelf,
+/obj/item/airlock_painter{
+	pixel_y = 3
+	},
+/obj/item/airlock_painter/decal{
+	pixel_y = -3
+	},
+/obj/item/airlock_painter/decal/tile{
+	pixel_y = -9
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/commons/storage/art)
 "kmQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -59212,6 +60838,9 @@
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
+"knh" = (
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "knM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -59245,21 +60874,13 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/engineering/break_room)
-"kqP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	dir = 8;
-	name = "Bar Access";
-	req_access_txt = "25"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/service/bar)
 "krD" = (
-/turf/closed/wall,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/research/glass{
+	name = "Circuitry Lab Storage";
+	req_access_txt = "47"
+	},
+/turf/open/floor/plating,
 /area/science/circuit)
 "krL" = (
 /obj/structure/disposalpipe/segment,
@@ -59321,6 +60942,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"ksZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/kitchen)
 "ktz" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -59429,9 +61072,17 @@
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
 "kvK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
@@ -59455,7 +61106,6 @@
 /area/security/office)
 "kwD" = (
 /obj/structure/rack,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
@@ -59476,10 +61126,20 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "kxk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/science/research)
 "kxM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -59509,16 +61169,14 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "kyt" = (
-/obj/machinery/button/door{
-	id = "hop";
-	name = "Privacy Shutters Control";
-	pixel_x = -24;
-	pixel_y = -6;
-	req_access_txt = "28"
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
@@ -59550,6 +61208,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/locker)
+"kzk" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
+	},
+/obj/structure/sign/barsign{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/machinery/vending/clothing,
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "kzn" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -59579,13 +61250,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
-"kAc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/kitchen)
 "kAr" = (
 /obj/structure/table/wood,
 /obj/item/hand_tele,
@@ -59599,6 +61263,18 @@
 "kAx" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -59698,9 +61374,19 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "kBH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -59709,14 +61395,10 @@
 /turf/closed/wall/r_wall,
 /area/engineering/gravity_generator)
 "kCR" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/light,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/service/bar)
 "kCX" = (
 /obj/structure/cable{
@@ -59730,9 +61412,17 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "kDc" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 8;
+	freq = 1400;
+	location = "Bar"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
 /area/service/bar)
 "kDg" = (
 /obj/structure/cable/yellow{
@@ -59741,15 +61431,16 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
 "kDi" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/door/poddoor/preopen{
+	dir = 4;
 	id = "ceprivacy";
 	name = "privacy shutter"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "kDk" = (
@@ -59853,14 +61544,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/office)
 "kFZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor/preopen{
-	id = "rdprivacy";
-	name = "privacy shutter"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/command/heads_quarters/rd)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
 "kGl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -59897,6 +61588,18 @@
 	pixel_x = 27
 	},
 /obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -59944,7 +61647,7 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "kIw" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
@@ -60019,12 +61722,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engineering/main)
-"kKA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/service/bar)
 "kKH" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -60102,14 +61799,18 @@
 /turf/open/floor/plasteel,
 /area/command/gateway)
 "kMT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/commons/storage/art)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/effect/landmark/start/bartender,
+/turf/open/floor/wood,
+/area/service/bar)
 "kNr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -60144,11 +61845,18 @@
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "kOt" = (
-/obj/item/multitool,
-/obj/item/screwdriver,
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_y = 30;
+	receive_ore_updates = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -60191,11 +61899,11 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "kPZ" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/service/bar)
 "kQh" = (
 /obj/structure/cable/yellow{
@@ -60214,19 +61922,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
-"kQJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
 "kQP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -60339,7 +62034,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "kSF" = (
-/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "kSV" = (
@@ -60390,6 +62090,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
+"kTF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "kTS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -60435,13 +62139,11 @@
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/hop)
 "kVo" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/engine,
+/area/science/explab)
 "kVz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60491,12 +62193,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"kXk" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;27"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "kXp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/area/hallway/secondary/service)
 "kXt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -60550,13 +62272,10 @@
 "kYC" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light,
-/obj/machinery/power/apc{
-	areastring = "/area/hydroponics";
-	name = "Hydroponics APC";
-	pixel_y = -28
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60603,6 +62322,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
+"kYP" = (
+/obj/structure/table/reinforced,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/machinery/cell_charger,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "kYY" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -60649,7 +62375,16 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "lao" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -60680,23 +62415,15 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
 "lcj" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	dir = 8;
-	freq = 1400;
-	location = "Hydroponics"
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
 	},
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
-/area/service/hydroponics)
+/turf/open/floor/engine,
+/area/science/explab)
 "lcm" = (
 /obj/item/wrench,
 /obj/effect/turf_decal/stripes/line{
@@ -60812,6 +62539,18 @@
 	pixel_x = 24
 	},
 /obj/machinery/vending/dinnerware,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
 "leN" = (
@@ -60904,20 +62643,20 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "liF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "lja" = (
 /obj/structure/cable/yellow{
@@ -60926,14 +62665,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	dir = 8;
 	name = "Research Director's Office";
 	req_access_txt = "30"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -60983,10 +62725,14 @@
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "llb" = (
-/obj/structure/table/reinforced,
-/obj/item/integrated_circuit_printer,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/obj/structure/closet/crate,
+/obj/item/assembly/infra,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "llh" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -61023,11 +62769,12 @@
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "llF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall,
-/area/engineering/storage/tcomms)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "llY" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Long-Term Cell 1";
@@ -61136,18 +62883,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/cargo/office)
-"lrJ" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/toilet/auxiliary";
-	name = "Auxiliary Restrooms APC";
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
 "lrM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -61174,6 +62909,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"lso" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/kitchen)
 "ltc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -61251,12 +63005,29 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "lvu" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -61274,22 +63045,48 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
 "lvR" = (
-/obj/effect/landmark/start/bartender,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
 /area/service/bar)
+"lvV" = (
+/obj/machinery/door/airlock{
+	dir = 8;
+	id_tag = "Toilet2";
+	name = "Unit 2"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
+"lwe" = (
+/turf/closed/wall,
+/area/commons/toilet/auxiliary)
 "lwz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -61299,14 +63096,14 @@
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/hop)
 "lwN" = (
-/obj/structure/chair/stool/bar,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/service/bar)
+/area/hallway/primary/central)
 "lwX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot_white/right,
@@ -61385,6 +63182,10 @@
 	dir = 1
 	},
 /area/command/gateway)
+"lyL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/lab)
 "lyU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -61396,12 +63197,20 @@
 /turf/open/floor/engine/cult,
 /area/service/library)
 "lzk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "lzo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61429,6 +63238,12 @@
 	dir = 4
 	},
 /area/cargo/office)
+"lzs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "lzt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -61598,6 +63413,16 @@
 	},
 /turf/open/floor/plating,
 /area/service/lawoffice)
+"lEm" = (
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "lEx" = (
 /turf/closed/wall,
 /area/cargo/office)
@@ -61671,11 +63496,17 @@
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "lGk" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/service/kitchen)
@@ -61684,7 +63515,7 @@
 	name = "CondiMaster Neo";
 	pixel_x = -4
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "lGS" = (
 /obj/docking_port/stationary/public_mining_dock,
@@ -61709,6 +63540,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"lIk" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/freezer,
+/area/service/kitchen)
 "lIs" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/miner/carbon_dioxide,
@@ -61813,7 +63650,8 @@
 /turf/closed/wall,
 /area/command/bridge)
 "lMz" = (
-/obj/structure/falsewall,
+/obj/structure/target_stake,
+/obj/structure/target_stake,
 /turf/open/floor/plating,
 /area/science/circuit)
 "lMJ" = (
@@ -61898,12 +63736,12 @@
 	pixel_y = -32
 	},
 /obj/structure/table,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "lOt" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/item/bikehorn/rubberducky,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "lOv" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -61936,7 +63774,19 @@
 	},
 /turf/open/floor/plating,
 /area/command/gateway)
+"lPv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine{
+	dir = 9;
+	icon_state = "floor"
+	},
+/area/science/misc_lab/range)
 "lPE" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/service/bar)
@@ -61947,17 +63797,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"lQe" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "lQo" = (
-/obj/machinery/light/small{
+/obj/machinery/rnd/production/techfab/department/service,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/wood,
-/area/service/theater)
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "lQr" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -61970,9 +63833,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/mining/glass{
+	dir = 8;
 	name = "Mining Dock";
-	req_access_txt = "48";
-	dir = 8
+	req_access_txt = "48"
 	},
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
@@ -62083,7 +63946,7 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "lUk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -62185,10 +64048,11 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "lWq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/white,
 /area/service/bar)
 "lWX" = (
 /obj/structure/cable/yellow{
@@ -62220,6 +64084,18 @@
 	},
 /obj/item/reagent_containers/food/condiment/enzyme{
 	layer = 5
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
@@ -62255,6 +64131,9 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -62278,6 +64157,12 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"lYI" = (
+/obj/effect/landmark/xmastree,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/bar)
 "lYW" = (
 /obj/effect/turf_decal/loading_area{
 	icon_state = "trim"
@@ -62409,6 +64294,14 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"mdr" = (
+/obj/machinery/door/airlock{
+	dir = 4;
+	id_tag = "AuxToilet3";
+	name = "Unit 3"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "mdt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/runtime,
@@ -62424,8 +64317,19 @@
 /turf/open/floor/plasteel,
 /area/command/gateway)
 "mei" = (
-/turf/closed/wall,
-/area/commons/toilet/auxiliary)
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/commons/storage/art)
 "mex" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -62502,7 +64406,7 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "mgb" = (
 /obj/machinery/requests_console{
@@ -62605,6 +64509,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"mhW" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "mhX" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -62645,20 +64561,24 @@
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "mjp" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/structure/chair/stool/bar,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "mjJ" = (
-/obj/machinery/nuclearbomb/beer{
-	pixel_x = 2;
-	pixel_y = 6
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "mjX" = (
 /obj/structure/railing,
 /obj/structure/cable/yellow{
@@ -62730,13 +64650,10 @@
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "mmy" = (
+/obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "mmH" = (
@@ -62774,6 +64691,9 @@
 	},
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "moO" = (
@@ -62783,10 +64703,12 @@
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
 "moT" = (
-/obj/structure/table,
-/obj/item/camera,
-/turf/open/floor/plasteel,
-/area/commons/storage/art)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/service/bar)
 "moW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
@@ -62928,50 +64850,44 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
 "msI" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/service/bar)
 "mte" = (
-/obj/machinery/light/small,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -30
-	},
-/turf/open/floor/wood,
+/obj/effect/landmark/start/bartender,
+/turf/open/floor/plasteel/dark,
 /area/service/bar)
 "mtf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/curtain{
+	color = "#880202";
+	opacity = 1;
+	open = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/carpet/black,
+/area/service/bar)
+"mtn" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/service/bar)
-"mtH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
-/area/service/hydroponics)
+/area/science/mixing)
 "mtJ" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -63005,14 +64921,10 @@
 /turf/open/floor/plasteel,
 /area/command/gateway)
 "mvj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/hallway/secondary/service)
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/service/bar)
 "mvI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63059,30 +64971,25 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "mwN" = (
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Hydroponics Delivery";
-	req_access_txt = "35"
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
+/turf/open/floor/plasteel/white,
+/area/science/lab)
+"mwP" = (
+/obj/effect/landmark/start/botanist,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
-"mwP" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "mxh" = (
@@ -63135,6 +65042,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/office)
+"mxR" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "mxT" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -63188,6 +65111,15 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -63273,6 +65205,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"mBn" = (
+/obj/item/storage/toolbox/emergency,
+/obj/structure/closet/firecloset,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "mBW" = (
 /turf/open/floor/plasteel,
 /area/commons/locker)
@@ -63301,7 +65242,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "mDk" = (
 /obj/structure/cable/white{
@@ -63340,14 +65281,9 @@
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "mDX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/service/bar)
 "mEe" = (
 /obj/structure/sink{
@@ -63371,6 +65307,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/commons/fitness/recreation)
+"mEk" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "mEr" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -63424,19 +65368,8 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "mFH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "mGL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -63492,16 +65425,17 @@
 	},
 /turf/closed/wall/r_wall,
 /area/commons/storage/tools)
-"mHR" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/pie/plump_pie{
-	pixel_x = 3;
-	pixel_y = 11
+"mHB" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/snacks/burger/fish{
-	pixel_x = -3
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "mHZ" = (
 /obj/effect/landmark/xeno_spawn,
@@ -63531,10 +65465,24 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "mIG" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/bar)
 "mIR" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63542,15 +65490,11 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "mIW" = (
-/obj/machinery/computer/arcade,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/item/toy/cards/deck{
+	pixel_y = 4
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/carpet,
 /area/service/bar)
 "mJg" = (
 /obj/structure/table/wood,
@@ -63717,13 +65661,7 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "mPm" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/chair/sofa{
-	dir = 8
-	},
+/obj/machinery/vending/mealdor,
 /turf/open/floor/wood,
 /area/service/bar)
 "mPo" = (
@@ -63740,12 +65678,12 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "mPv" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/service/bar)
 "mPQ" = (
 /obj/structure/disposalpipe/segment,
@@ -63758,8 +65696,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"mQH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "mQW" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -63826,6 +65784,18 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solars/port/aft)
+"mSS" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "mTr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -63844,7 +65814,7 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "mTL" = (
 /obj/machinery/atmospherics/pipe/simple,
@@ -63898,6 +65868,16 @@
 "mVL" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engineering/break_room)
+"mWb" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -64081,24 +66061,20 @@
 /turf/open/floor/plating,
 /area/cargo/office)
 "naO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
-"nbl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/jukebox,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/service/bar)
 "nbs" = (
 /obj/structure/disposalpipe/segment,
@@ -64141,18 +66117,32 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "nfs" = (
-/obj/structure/mirror{
-	pixel_x = 28
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/commons/toilet/auxiliary)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/commons/storage/art)
 "nfO" = (
 /obj/machinery/door/airlock{
 	dir = 8;
 	id_tag = "Toilet1";
 	name = "Unit 1"
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "nfP" = (
 /obj/machinery/door/firedoor,
@@ -64174,20 +66164,11 @@
 	},
 /area/commons/fitness/recreation)
 "ngZ" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/structure/chair/sofa/left,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	pixel_y = 12
 	},
-/obj/machinery/camera{
-	c_tag = "Club - Fore"
-	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/service/bar)
 "nho" = (
@@ -64230,13 +66211,28 @@
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
 "nia" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/wood/fancy/red,
+/obj/item/ashtray{
+	name = "candle holder"
 	},
-/obj/structure/chair/sofachair{
-	dir = 1
+/obj/item/candle{
+	pixel_y = 12
 	},
-/turf/open/floor/wood,
+/obj/item/candle{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/obj/item/candle{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = 6
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -30
+	},
+/turf/open/floor/carpet,
 /area/service/bar)
 "nid" = (
 /obj/structure/disposalpipe/segment{
@@ -64477,13 +66473,24 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "npo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/landmark/xeno_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/door/airlock/maintenance{
+	dir = 8;
+	req_one_access_txt = "12;25;46"
 	},
-/turf/open/floor/wood,
-/area/service/bar)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "npE" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel,
@@ -64533,14 +66540,32 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/commons/dorms)
-"nry" = (
-/obj/machinery/door/airlock{
-	dir = 8;
-	id_tag = "Toilet1";
-	name = "Unit 1"
+"nri" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
+"nry" = (
+/obj/structure/table,
+/obj/item/camera,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/commons/storage/art)
 "nsg" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -64618,8 +66643,8 @@
 "nxP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	name = "Library";
-	dir = 8
+	dir = 8;
+	name = "Library"
 	},
 /turf/open/floor/wood,
 /area/service/library)
@@ -64631,6 +66656,19 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
+"nya" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals - Aft Arm";
+	dir = 10
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "nyg" = (
 /obj/machinery/door/airlock{
 	dir = 8;
@@ -64643,14 +66681,17 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "nyo" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/turf/open/floor/carpet/black,
+/area/service/hydroponics)
 "nyA" = (
 /obj/machinery/shower{
 	dir = 8
@@ -64660,22 +66701,32 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
+/obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/research)
 "nzp" = (
-/obj/structure/urinal{
-	pixel_y = 29
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/commons/toilet/auxiliary)
+/area/maintenance/port)
 "nzz" = (
-/obj/machinery/vending/boozeomat,
-/turf/closed/wall,
-/area/service/bar)
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/tcommsat/computer";
+	dir = 4;
+	name = "Telecomms Control Room APC";
+	pixel_x = 26
+	},
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/folder,
+/obj/item/pen,
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "nzH" = (
 /turf/open/floor/wood,
 /area/service/hydroponics/garden)
@@ -64703,32 +66754,36 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "nAD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark/side,
 /area/cargo/sorting)
 "nAG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "nBJ" = (
-/obj/effect/spawner/lootdrop/costume,
-/obj/structure/trash_pile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/service/theater)
 "nBX" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -64737,9 +66792,45 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"nCa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"nCW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/service/bar)
 "nDn" = (
 /turf/closed/wall/r_wall,
 /area/command/corporate_showroom)
+"nDv" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nEw" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -64787,18 +66878,25 @@
 	dir = 1
 	},
 /area/hallway/primary/port)
+"nEH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "nFz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "nFG" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/service/bar)
 "nFS" = (
 /obj/structure/disposalpipe/segment,
@@ -64848,16 +66946,10 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "nGs" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/service/bar)
 "nHn" = (
 /obj/structure/cable{
@@ -64871,6 +66963,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"nHw" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "nHL" = (
 /obj/machinery/light{
 	dir = 4
@@ -64916,11 +67014,15 @@
 	},
 /area/service/hydroponics/garden)
 "nJo" = (
-/obj/structure/chair/sofa/left{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/service/bar)
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;27;37"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "nJr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -64936,25 +67038,18 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/machinery/requests_console{
-	department = "Hydroponics";
-	departmentType = 2;
-	pixel_x = -31;
-	pixel_y = -2
-	},
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
 	},
+/obj/item/storage/box/syringes,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "nKP" = (
@@ -64978,6 +67073,30 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"nKV" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
+"nLm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nLx" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -65027,6 +67146,21 @@
 "nLT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
@@ -65091,17 +67225,23 @@
 	pixel_x = -27
 	},
 /obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "nPo" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
-/obj/machinery/button/door{
-	id = "kitchenhydro";
-	name = "Service Shutter Control";
-	pixel_y = -24;
-	req_access_txt = "28"
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -65164,6 +67304,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
+"nQA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nQV" = (
 /turf/open/floor/plasteel/grimy,
 /area/security/office)
@@ -65176,14 +67327,19 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
 "nSv" = (
-/turf/closed/wall,
+/obj/machinery/door/poddoor/preopen{
+	id = "rdprivacy";
+	name = "privacy shutter"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
 /area/command/heads_quarters/rd)
 "nSP" = (
 /obj/effect/turf_decal/delivery,
@@ -65236,6 +67392,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/storage/tcomms)
 "nUi" = (
@@ -65259,12 +67417,10 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "nUs" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/burrito,
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
-/obj/machinery/light,
+/obj/effect/spawner/lootdrop/keg,
 /turf/open/floor/wood,
 /area/service/bar)
 "nUt" = (
@@ -65350,10 +67506,11 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/tools)
 "nWb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "nWG" = (
@@ -65363,14 +67520,15 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "nWX" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/item/cigbutt,
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/maintenance/port";
+	name = "Port Maintenance APC";
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/commons/toilet/auxiliary)
+/obj/structure/cable/yellow,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
 "nXe" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -65405,6 +67563,16 @@
 /obj/structure/chair/bench/right,
 /turf/open/floor/wood,
 /area/service/library)
+"nXX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
 "nYk" = (
 /obj/machinery/shower{
 	dir = 4
@@ -65412,7 +67580,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "nYm" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -65425,8 +67593,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "nYq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
@@ -65477,21 +67645,23 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "nZB" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
+/obj/effect/landmark/start/botanist,
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
+"nZE" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
-"nZE" = (
+/obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "nZH" = (
@@ -65501,16 +67671,10 @@
 	freq = 1400;
 	location = "Kitchen"
 	},
-/obj/structure/plasticflaps/opaque,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -65555,12 +67719,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
+"oak" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/science/circuit)
 "oao" = (
-/obj/structure/chair/sofa{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/service/bar)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oav" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -65619,22 +67791,15 @@
 /turf/open/floor/carpet/green,
 /area/service/library)
 "oaZ" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "obb" = (
-/obj/structure/target_stake,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/item/reagent_containers/food/snacks/pizza/meat{
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel,
-/area/science/circuit)
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/carpet/purple,
+/area/science/research)
 "obX" = (
 /obj/docking_port/stationary{
 	area_type = /area/construction/mining/aux_base;
@@ -65643,8 +67808,8 @@
 	height = 9;
 	name = "aux base zone";
 	roundstart_template = /datum/map_template/shuttle/aux_base/default;
-	width = 9;
-	shuttle_id = "aux_base_zone"
+	shuttle_id = "aux_base_zone";
+	width = 9
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
@@ -65655,17 +67820,12 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "ocT" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/obj/machinery/computer/security/telescreen/circuitry{
-	pixel_y = 30
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -65688,7 +67848,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "oda" = (
 /obj/machinery/door/poddoor/preopen{
@@ -65910,6 +68075,11 @@
 /obj/item/toy/poolnoodle/blue,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"oga" = (
+/obj/structure/fluff/railing,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ogf" = (
 /obj/structure/table/wood,
 /obj/item/stamp/captain,
@@ -65930,10 +68100,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
+"ohK" = (
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "oiv" = (
 /obj/structure/sign/warning/pods,
 /turf/closed/wall,
 /area/commons/locker)
+"oiS" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "oiY" = (
 /obj/machinery/light,
 /obj/structure/rack,
@@ -65964,6 +68142,15 @@
 /obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
+"ojy" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "ojC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/disposalpipe/segment,
@@ -66038,16 +68225,22 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter)
+"okY" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "olc" = (
 /obj/machinery/light/small,
 /obj/machinery/recharge_station,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "olw" = (
 /obj/machinery/door/airlock/atmos/glass{
+	dir = 4;
 	name = "Atmospherics Monitoring";
-	req_access_txt = "24";
-	dir = 4
+	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -66068,6 +68261,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"omw" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/rd)
 "omQ" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -66100,18 +68297,17 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "onz" = (
-/obj/structure/table,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/twentythreeXnineteen,
-/obj/item/canvas/twentythreeXnineteen,
-/obj/item/canvas/nineteenXnineteen,
-/obj/item/canvas/nineteenXnineteen,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/turf/open/floor/plasteel,
-/area/commons/storage/art)
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -10
+	},
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
+	},
+/turf/open/floor/wood,
+/area/service/bar)
 "ooc" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/window/reinforced{
@@ -66184,17 +68380,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
-"opk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/kitchen)
 "opw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -66289,9 +68474,9 @@
 "osB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
+	dir = 8;
 	name = "Escape Pod Four";
-	req_access_txt = "32";
-	dir = 8
+	req_access_txt = "32"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
@@ -66308,9 +68493,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
+	dir = 4;
 	name = "Supply Dock Airlock";
-	req_access_txt = "31";
-	dir = 4
+	req_access_txt = "31"
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
@@ -66392,6 +68577,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "ovB" = (
@@ -66456,14 +68643,30 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "ozl" = (
-/obj/structure/sign/poster/contraband/clown{
-	pixel_x = 32
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "ozS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -66492,29 +68695,43 @@
 /area/ai_monitored/command/storage/eva)
 "ozV" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 25
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
-"oAw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/commons/storage/art)
+"oAw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -66527,8 +68744,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -66547,15 +68770,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solars/port/fore)
-"oBB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/start/bartender,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/service/bar)
 "oBF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -66596,13 +68810,13 @@
 /turf/open/space,
 /area/engineering/atmos)
 "oCy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "oCQ" = (
@@ -66647,13 +68861,7 @@
 	pixel_y = 26
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+	icon_state = "0-8"
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
@@ -66671,10 +68879,29 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
 /area/service/kitchen)
+"oFP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/kink,
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "oGd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -66698,7 +68925,15 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "oIi" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/camera{
+	c_tag = "Club - Fore";
+	pixel_y = 12
+	},
+/obj/machinery/computer/arcade,
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
+	},
 /turf/open/floor/carpet/black,
 /area/service/bar)
 "oIN" = (
@@ -66750,13 +68985,22 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "oKf" = (
-/obj/item/wrench,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/accessory/armband/hydro,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/obj/machinery/computer/arcade{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/science/research)
 "oKi" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -66775,6 +69019,10 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
+"oKW" = (
+/obj/structure/sign/departments/restroom,
+/turf/closed/wall,
+/area/hallway/secondary/exit/departure_lounge)
 "oKY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -66815,18 +69063,12 @@
 /turf/open/floor/plasteel,
 /area/commons/dorms)
 "oLW" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/requests_console{
-	department = "Science";
-	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = 30;
-	receive_ore_updates = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/integrated_electronics/debugger,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "oMe" = (
@@ -66903,6 +69145,22 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
+"oOU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/storage/box/lights/mixed,
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/port)
 "oOW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -66996,6 +69254,22 @@
 /obj/structure/scale,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"oQX" = (
+/obj/structure/urinal{
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
+"oRg" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/trash_pile,
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "oRp" = (
 /turf/closed/mineral/random/low_chance,
 /area/space/station_ruins)
@@ -67019,8 +69293,8 @@
 	dwidth = 11;
 	height = 22;
 	name = "SS13: Auxiliary Dock, Station-Port";
-	width = 35;
-	shuttle_id = "whiteship_home"
+	shuttle_id = "whiteship_home";
+	width = 35
 	},
 /turf/open/space/basic,
 /area/space)
@@ -67130,17 +69404,18 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "oUA" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "telelab";
+	name = "test chamber blast door"
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/science/explab)
 "oUJ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon{
@@ -67156,10 +69431,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
-"oVF" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)"
+"oVa" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"oVF" = (
+/obj/structure/sign/carts,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "oVH" = (
@@ -67374,38 +69654,28 @@
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "pbc" = (
-/obj/machinery/computer/arcade,
-/obj/item/reagent_containers/food/drinks/bottle/gin{
-	pixel_x = 16;
-	pixel_y = 8
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/obj/structure/sign/poster/random{
-	pixel_x = -32
-	},
-/turf/open/floor/carpet,
+/obj/structure/table,
+/obj/item/storage/box/donkpockets/donkpocketpizza,
+/turf/open/floor/carpet/black,
 /area/science/research)
 "pbQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/ai_monitored/aisat/exterior)
 "pcc" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/disposal/bin,
+/obj/item/grown/corncob{
+	pixel_x = 10;
+	pixel_y = -12
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "pcd" = (
@@ -67442,6 +69712,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/office)
+"pcx" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "floor_whole"
+	},
+/area/hallway/primary/central)
 "pcy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/command,
@@ -67483,7 +69770,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "pdH" = (
 /obj/item/tank/internals/oxygen/red{
@@ -67536,13 +69823,16 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "peh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
 	},
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "trim"
+	},
+/turf/open/floor/carpet/black,
 /area/service/hydroponics)
 "peX" = (
 /obj/machinery/airalarm{
@@ -67552,14 +69842,13 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "pfi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "rdprivacy";
 	name = "privacy shutter"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
@@ -67576,6 +69865,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
@@ -67671,15 +69963,16 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "piB" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
+/obj/machinery/chem_master/condimaster{
+	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
+	name = "BrewMaster 2199"
 	},
-/obj/structure/noticeboard{
-	desc = "A board for pinning important notices upon. Probably helpful for keeping track of requests.";
-	name = "requests board";
-	pixel_y = 32
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "pjr" = (
@@ -67714,9 +70007,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "pjR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -67736,19 +70026,26 @@
 /turf/open/floor/plasteel,
 /area/commons/dorms)
 "pky" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/science/research";
-	dir = 8;
-	name = "Security Post - Research Division APC";
-	pixel_x = -24
-	},
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = -8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
@@ -67878,9 +70175,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
+	dir = 4;
 	name = "Security External Airlock";
-	req_access_txt = "1";
-	dir = 4
+	req_access_txt = "1"
 	},
 /turf/open/floor/plating,
 /area/security/prison)
@@ -67918,21 +70215,15 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
-"poo" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/bar)
 "poT" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/hop";
 	dir = 1;
 	name = "Head of Personnel APC";
 	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
@@ -67977,6 +70268,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
+"pqt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "pqG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/bed,
@@ -68066,18 +70361,6 @@
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
 "psM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/starboard";
-	dir = 1;
-	name = "Starboard Hallway APC";
-	pixel_y = 26
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -68141,9 +70424,6 @@
 /turf/closed/wall,
 /area/security/prison)
 "pvA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -68153,12 +70433,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "pvK" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "pvU" = (
@@ -68191,29 +70475,19 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "pwY" = (
-/obj/item/seeds/wheat,
-/obj/item/seeds/sugarcane,
-/obj/item/seeds/potato,
-/obj/item/seeds/apple,
-/obj/item/grown/corncob,
-/obj/item/reagent_containers/food/snacks/grown/carrot,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/pumpkin{
-	pixel_y = 5
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera/autoname{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "pxg" = (
@@ -68261,15 +70535,17 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "pyj" = (
-/obj/structure/table,
-/obj/item/paper_bin/construction,
-/obj/item/airlock_painter,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/commons/storage/art)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/service/bar)
 "pyW" = (
 /obj/item/cartridge/medical{
 	pixel_x = -2;
@@ -68353,13 +70629,18 @@
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
 "pzY" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/service/bar)
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/commons/storage/art)
 "pAk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -68406,9 +70687,6 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -68419,7 +70697,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "pCP" = (
 /obj/structure/closet/secure_closet/medical1,
@@ -68450,9 +70728,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "pDa" = (
@@ -68467,9 +70747,9 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
+	dir = 4;
 	name = "Atmospherics External Airlock";
-	req_access_txt = "24";
-	dir = 4
+	req_access_txt = "24"
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -68489,13 +70769,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
-"pDn" = (
-/obj/effect/turf_decal/bot,
-/obj/vehicle/ridden/grocery_cart{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
 "pDz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -68522,15 +70795,19 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "pGg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/landmark/start/clown,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "pGj" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -68665,14 +70942,15 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "pIJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "pJd" = (
 /obj/structure/window/reinforced,
@@ -68702,14 +70980,14 @@
 /turf/open/floor/carpet/red,
 /area/commons/locker)
 "pKa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/structure/medkit_cabinet{
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -68829,11 +71107,18 @@
 "pOS" = (
 /turf/closed/wall/r_wall,
 /area/security/office)
-"pPp" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/machinery/light_switch{
-	pixel_x = -26
+"pPj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"pPp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "pPG" = (
@@ -68891,14 +71176,21 @@
 /turf/open/space,
 /area/solars/starboard/aft)
 "pRp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/carpet,
 /area/service/bar)
 "pRA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -68954,26 +71246,32 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "pSX" = (
-/obj/machinery/door/airlock/external{
-	name = "Auxiliary Escape Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel/white,
+/area/service/bar)
 "pSY" = (
 /turf/closed/wall,
 /area/service/hydroponics/garden)
 "pTr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "pTI" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -69025,12 +71323,8 @@
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "pUJ" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/gambling{
-	pixel_y = 7
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/chair/sofa/right{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/service/bar)
@@ -69122,15 +71416,25 @@
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
+"pXo" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "pXC" = (
-/obj/machinery/camera{
-	c_tag = "Club - Private Room";
+/obj/effect/spawner/lootdrop/keg,
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
 	dir = 8
 	},
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/turf/open/floor/carpet/black,
 /area/service/bar)
 "pXT" = (
 /obj/structure/window/reinforced,
@@ -69141,16 +71445,11 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "pYn" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Art Storage"
+/obj/structure/chair/sofa/left{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/commons/storage/art)
+/turf/open/floor/carpet,
+/area/service/bar)
 "pYN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69227,6 +71526,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
+"qaz" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qaA" = (
 /obj/structure/window/reinforced,
 /obj/machinery/light/small,
@@ -69335,14 +71638,26 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "qfe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -69376,30 +71691,24 @@
 	},
 /area/service/chapel/main)
 "qfY" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
 	},
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/obj/structure/table/glass,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 2
+	},
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/wood,
 /area/service/bar)
 "qgb" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "AuxToilet2";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/obj/structure/trash_pile,
+/obj/structure/fluff/railing,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "qgP" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69427,6 +71736,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/locker)
+"qgZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/bar)
 "qha" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -69680,6 +72005,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"qmX" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/kitchen)
 "qnv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -69707,7 +72052,7 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "qoi" = (
-/obj/structure/sign/poster/official/random,
+/obj/structure/sign/poster/random,
 /turf/closed/wall,
 /area/service/kitchen)
 "qoA" = (
@@ -69823,8 +72168,14 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "qqg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -69845,10 +72196,10 @@
 /area/cargo/office)
 "qqM" = (
 /obj/effect/turf_decal/tile/green{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -70103,24 +72454,32 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "qAS" = (
-/obj/machinery/plantgenes{
-	pixel_y = 6
-	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
-"qBh" = (
-/obj/structure/table,
-/obj/item/paicard,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"qBh" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/explab)
 "qBl" = (
 /obj/machinery/computer/bounty,
 /obj/effect/turf_decal/loading_area{
@@ -70336,6 +72695,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
+"qGT" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "qHe" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -70364,13 +72731,19 @@
 	},
 /turf/open/floor/carpet,
 /area/service/library)
+"qIa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "qIn" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/vending/mealdor,
-/turf/open/floor/wood,
+/turf/closed/wall,
 /area/service/bar)
 "qIp" = (
 /obj/machinery/computer/mecha{
@@ -70393,11 +72766,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
-"qIB" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/burger/bigbite,
-/turf/open/floor/wood,
-/area/service/bar)
 "qID" = (
 /obj/structure/sign/warning/securearea,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -70448,12 +72816,36 @@
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/hos)
 "qJk" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/chair/stool/bar/bronze,
-/turf/open/floor/carpet,
-/area/service/bar)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"qJq" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "AuxToilet3";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = 26;
+	specialfunctions = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "qJF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -70530,24 +72922,12 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "qMA" = (
-/obj/structure/table,
-/obj/machinery/power/apc{
-	areastring = "/area/storage/art";
-	dir = 8;
-	name = "Art Storage APC";
-	pixel_x = -25
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/item/paper_bin,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/turf/open/floor/plasteel,
-/area/commons/storage/art)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/service/bar)
 "qNe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
@@ -70579,21 +72959,24 @@
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
 "qOT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "qPs" = (
-/obj/machinery/door/airlock{
-	dir = 8;
-	id_tag = "Toilet2";
-	name = "Unit 2"
+/obj/effect/turf_decal/bot,
+/obj/structure/railing,
+/obj/vehicle/ridden/grocery_cart{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/turf/open/floor/engine,
+/area/hallway/secondary/entry)
 "qPw" = (
 /obj/structure/pool/Lboard,
 /turf/open/pool,
@@ -70614,6 +72997,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
+"qQE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "qQR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -70660,13 +73047,19 @@
 	},
 /area/cargo/office)
 "qSJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/service/kitchen)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qSK" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/sign/map/right{
@@ -70885,8 +73278,10 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "qWu" = (
-/obj/machinery/vending/gato,
-/turf/open/floor/wood,
+/obj/machinery/smartfridge/drinks{
+	icon_state = "boozeomat"
+	},
+/turf/closed/wall,
 /area/service/bar)
 "qWR" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -71082,17 +73477,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/office)
-"rbX" = (
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/beer,
-/turf/open/floor/wood,
-/area/service/bar)
 "rcc" = (
 /obj/structure/window/reinforced,
 /obj/machinery/computer/cargo/request{
@@ -71114,6 +73498,27 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/command/teleporter)
+"rcz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "rcL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -71214,6 +73619,27 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -71224,8 +73650,9 @@
 /turf/open/floor/carpet/orange,
 /area/commons/locker)
 "rfm" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/service/bar)
 "rfr" = (
@@ -71398,10 +73825,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/captain/private)
-"rjg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+"riH" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/dark/side,
+/area/hallway/primary/central)
+"rjg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -71442,9 +73876,9 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "rlw" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/chair/sofa/left{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/service/bar)
@@ -71502,9 +73936,17 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "rmu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics Maintenance";
+	req_access_txt = "35"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "rns" = (
@@ -71602,12 +74044,22 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "rqx" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/commons/toilet/auxiliary)
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/bar)
 "rqG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -71618,24 +74070,23 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
+"rry" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/clothing/suit/apron,
+/obj/item/clothing/mask/surgical,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard/aft)
 "rrD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "rrX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "rdprivacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/command/heads_quarters/rd)
 "rsm" = (
 /obj/machinery/light,
@@ -71711,6 +74162,15 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"rvm" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "rvr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -71748,6 +74208,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"rwh" = (
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Escape Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "rwk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -71893,8 +74360,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tcomms)
@@ -71921,15 +74389,25 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "rzT" = (
-/obj/machinery/door/window/southleft{
-	name = "Bar Delivery";
-	req_access_txt = "25"
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/tile/bar{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "rzX" = (
 /obj/structure/chair/office/light{
@@ -71981,21 +74459,21 @@
 /turf/open/floor/carpet/red,
 /area/commons/locker)
 "rCH" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /obj/machinery/door/airlock{
 	dir = 8;
 	name = "Kitchen Cold Room";
 	req_access_txt = "28"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "rCK" = (
 /obj/item/stack/sheet/plasteel{
@@ -72162,16 +74640,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "rIw" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/research)
 "rJc" = (
 /turf/closed/wall,
 /area/command/teleporter)
@@ -72193,6 +74664,13 @@
 	},
 /turf/open/floor/carpet/gato,
 /area/commons/dorms)
+"rJS" = (
+/obj/structure/table/reinforced,
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_electronics/debugger,
+/obj/item/integrated_electronics/wirer,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "rJT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -72210,7 +74688,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "rKe" = (
 /obj/machinery/door/firedoor,
@@ -72398,6 +74876,18 @@
 "rQj" = (
 /obj/effect/landmark/start/cook,
 /obj/machinery/holopad,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
 "rQv" = (
@@ -72405,8 +74895,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -72503,36 +74994,42 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "rSO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/westright{
-	dir = 4;
-	name = "Hydroponics Desk";
-	req_one_access_txt = "30;35"
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_whole"
+	},
+/area/hallway/primary/central)
+"rSU" = (
+/obj/effect/landmark/blobstart,
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/space)
+"rTi" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "rTj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -72543,8 +75040,23 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "rTl" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -72573,6 +75085,19 @@
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
 "rUl" = (
@@ -72650,16 +75175,13 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "rWE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/closed/wall,
-/area/service/theater)
+/area/hallway/secondary/service)
 "rXs" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "rYf" = (
 /obj/machinery/door/window{
@@ -72682,8 +75204,15 @@
 /area/command/bridge)
 "rYI" = (
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/carpet,
 /area/service/bar)
 "rYK" = (
@@ -72698,6 +75227,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
+"rZs" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"saa" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/aft)
 "saf" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -72911,14 +75467,31 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
-"seD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
+"seI" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/service/bar)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "seS" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -72940,19 +75513,22 @@
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "sfb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8
+	dir = 1
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "sfl" = (
@@ -73111,7 +75687,6 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/paper,
 /obj/machinery/door/window/eastleft{
 	dir = 2;
@@ -73119,7 +75694,11 @@
 	req_one_access_txt = "30;35"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenhydro";
+	name = "Service Shutter"
+	},
+/turf/open/floor/plating,
 /area/service/hydroponics)
 "skf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -73185,21 +75764,19 @@
 /obj/item/stamp/hos,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"smm" = (
-/obj/machinery/shower{
-	dir = 4
+"slM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/button/door{
-	id = "AuxShower";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_y = 25;
-	specialfunctions = 4
-	},
-/obj/item/soap/nanotrasen,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/area/science/storage)
+"smm" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
 "smu" = (
 /obj/machinery/computer/teleporter{
 	dir = 4
@@ -73207,9 +75784,16 @@
 /turf/open/floor/plating,
 /area/command/teleporter)
 "smA" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/turf/open/floor/wood,
-/area/service/bar)
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed,
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "smH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73312,6 +75896,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"spp" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "spx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -73542,13 +76132,38 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "syK" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/disposalpipe/junction/flip{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/structure/table/wood,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/service/bar)
+"szl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/requests_console{
+	department = "Science";
+	departmentType = 2;
+	name = "Science Requests Console";
+	pixel_x = 32;
+	receive_ore_updates = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "szt" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -73612,6 +76227,15 @@
 /obj/item/pen/invisible,
 /turf/open/floor/engine/cult,
 /area/service/library)
+"sBf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "sBz" = (
 /obj/structure/chair{
 	dir = 1
@@ -73661,13 +76285,22 @@
 	icon_state = "wood-broken3"
 	},
 /area/maintenance/port/aft)
+"sCS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/explab)
 "sCT" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/vending/games,
 /turf/open/floor/wood,
 /area/service/library)
 "sDM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -73721,22 +76354,14 @@
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
 "sFv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	dir = 8;
-	req_access_txt = "47"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/science/circuit)
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "sFR" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -73894,6 +76519,18 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"sJE" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "toxins_blastdoor";
+	name = "biohazard containment door"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "sJT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -74007,17 +76644,11 @@
 	},
 /area/hallway/primary/port)
 "sNj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/bar)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sOy" = (
 /obj/structure/rack,
 /obj/item/lighter,
@@ -74084,6 +76715,18 @@
 /area/commons/storage/primary)
 "sPW" = (
 /obj/effect/landmark/start/cook,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
 "sQx" = (
@@ -74172,16 +76815,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
+"sSy" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "sTr" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
-"sTt" = (
-/obj/structure/sign/poster/random,
-/turf/closed/wall,
-/area/service/bar)
 "sTB" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/miner/nitrogen,
@@ -74202,6 +76853,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
+"sUc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "sUd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -74216,14 +76873,26 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "sUI" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = 22
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
 /area/service/bar)
+"sVh" = (
+/obj/structure/sign/map/left{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-left-MS";
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "sVv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -74266,10 +76935,7 @@
 /area/security/office)
 "sVW" = (
 /obj/machinery/icecream_vat,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "sWZ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
@@ -74306,6 +76972,29 @@
 	},
 /turf/open/floor/carpet/green,
 /area/service/library)
+"sYw" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "AuxToilet2";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_x = -8;
+	pixel_y = 26;
+	specialfunctions = 4
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/reagent_containers/food/snacks/sausage,
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "sYL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -74334,13 +77023,16 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "sZJ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/bar,
+/obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/tile/bar{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "sZM" = (
 /obj/machinery/power/apc{
@@ -74364,15 +77056,11 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/tools)
 "sZN" = (
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
 /obj/effect/turf_decal/bot,
-/obj/structure/railing{
-	dir = 8
+/obj/vehicle/ridden/grocery_cart{
+	dir = 4
 	},
-/obj/vehicle/ridden/grocery_cart,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "sZV" = (
 /obj/effect/turf_decal/stripes/line,
@@ -74430,6 +77118,13 @@
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
+"tbs" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "tbN" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -74471,7 +77166,7 @@
 /area/engineering/main)
 "tdK" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "tdP" = (
 /obj/structure/cable/yellow{
@@ -74509,14 +77204,17 @@
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
 "tej" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/service/bar)
@@ -74541,14 +77239,19 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "teR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/sign/poster/random{
+	pixel_x = 32
 	},
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
+/obj/structure/chair/comfy/black,
+/turf/open/floor/carpet,
+/area/service/bar)
 "teZ" = (
-/turf/closed/wall,
-/area/commons/storage/art)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/wood,
+/area/service/bar)
 "tfk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -74559,6 +77262,12 @@
 /obj/item/trash/boritos,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"tfx" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
 "tfL" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -74594,13 +77303,6 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/cargo/storage)
-"tfX" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/structure/chair/stool/brass,
-/turf/open/floor/wood,
-/area/service/bar)
 "tgn" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/transmitter,
@@ -74619,9 +77321,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tcomms)
@@ -74663,6 +77362,15 @@
 	dir = 4
 	},
 /area/commons/fitness/recreation)
+"thF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tie" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -74821,8 +77529,12 @@
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
 "tlF" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "tmg" = (
 /turf/closed/wall,
@@ -74899,6 +77611,18 @@
 /area/engineering/main)
 "tpe" = (
 /obj/structure/table,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -74912,6 +77636,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"tpK" = (
+/turf/closed/wall,
+/area/science/lab)
 "tpO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -74946,10 +77673,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "tre" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "trj" = (
 /obj/effect/turf_decal/bot_white/right,
@@ -74973,6 +77697,19 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
+"tsg" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "tsn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -74983,8 +77720,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
@@ -75048,13 +77791,19 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "tuB" = (
-/obj/machinery/door/airlock{
-	name = "Theatre Backstage";
-	req_access_txt = "46"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/service/theater)
+/turf/open/floor/carpet,
+/area/service/bar)
+"tvw" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine{
+	dir = 9;
+	icon_state = "floor"
+	},
+/area/science/misc_lab/range)
 "txb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -75073,8 +77822,9 @@
 /area/tcommsat/computer)
 "txj" = (
 /obj/structure/chair/office/light{
-	dir = 1
+	dir = 4
 	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "txq" = (
@@ -75098,6 +77848,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/locker)
+"tyj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/service/hydroponics)
 "tyt" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -75114,21 +77869,14 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "tyM" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/requests_console{
+	department = "Hydroponics";
+	departmentType = 2;
+	pixel_x = 32;
+	pixel_y = -2
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
-"tyY" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/ale,
-/turf/open/floor/wood,
-/area/service/bar)
 "tzk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -75142,14 +77890,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tzl" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
-/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/service/bar)
 "tzp" = (
@@ -75176,21 +77928,12 @@
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
 "tCA" = (
-/obj/machinery/disposal/bin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway - Aft-Starboard";
 	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /turf/open/floor/plasteel,
-/area/service/hydroponics)
+/area/hallway/primary/central)
 "tCH" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/plasteel,
@@ -75243,6 +77986,16 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
+"tEO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;27;37"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "tFp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -75257,6 +78010,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"tFt" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "tFA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -75321,7 +78080,10 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/treatment_center)
 "tHs" = (
-/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "tHz" = (
@@ -75330,6 +78092,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"tHJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/science/circuit";
+	dir = 1;
+	name = "Circuitry Lab APC";
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "tHP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -75348,25 +78122,36 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
+"tIu" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "tIB" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	name = "Hydroponics Desk";
 	req_one_access_txt = "30;35"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchenhydro";
+	name = "Service Shutter"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/service/hydroponics)
 "tIF" = (
 /obj/item/storage/belt/utility,
@@ -75470,16 +78255,16 @@
 /turf/open/floor/plasteel/dark,
 /area/construction/storage_wing)
 "tKM" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 10
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "tLi" = (
 /turf/closed/wall,
@@ -75645,6 +78430,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
+"tPi" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "tPJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -75747,7 +78536,15 @@
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
 "tRn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/carpet,
 /area/service/bar)
 "tSa" = (
@@ -75762,22 +78559,15 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "tTX" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/chair/sofachair,
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/carpet,
 /area/service/bar)
 "tUa" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/vehicle/ridden/grocery_cart,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "tUN" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -75823,18 +78613,25 @@
 /turf/open/floor/plasteel/stairs/right,
 /area/cargo/storage)
 "tUY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -75865,6 +78662,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "tVY" = (
@@ -75877,7 +78675,7 @@
 /obj/item/target/syndicate,
 /obj/item/gun/energy/laser/practice,
 /obj/item/gun/energy/laser/practice,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/science/circuit)
 "tWo" = (
 /obj/effect/landmark/xeno_spawn,
@@ -75894,9 +78692,6 @@
 "tWp" = (
 /obj/structure/closet{
 	name = "spare parts locker"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /obj/item/rack_parts,
 /obj/item/rack_parts,
@@ -75959,6 +78754,18 @@
 /area/ai_monitored/aisat/exterior)
 "tXZ" = (
 /obj/machinery/food_cart,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -76028,9 +78835,12 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "uam" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/nuclearbomb/beer{
+	pixel_x = 2;
+	pixel_y = 6
+	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/aft)
 "uar" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -76057,22 +78867,29 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ubH" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ubJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/machinery/light/small{
+/obj/machinery/power/apc{
+	areastring = "/area/storage/art";
+	dir = 8;
+	name = "Art Storage APC";
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/commons/storage/art)
 "ubO" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -76176,7 +78993,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -76235,6 +79059,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
+"ugb" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/space_heater,
+/obj/structure/fluff/railing,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ugm" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -76258,9 +79088,20 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/engineering/atmos)
 "uhi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/engineering/storage/tech)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uhB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -76280,10 +79121,6 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "uih" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -76292,6 +79129,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -76410,15 +79250,12 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "ulI" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "ulQ" = (
 /obj/machinery/door/window/brigdoor{
@@ -76478,6 +79315,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"umI" = (
+/obj/structure/rack,
+/obj/item/extinguisher,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "umO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76503,10 +79346,34 @@
 	pixel_x = 30
 	},
 /obj/machinery/processor,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
 "unK" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -76566,28 +79433,39 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solars/starboard/fore)
 "upD" = (
-/obj/structure/sign/carts,
-/turf/closed/wall,
-/area/commons/vacant_room/office)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "upN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "upO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "uqh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -76608,12 +79486,17 @@
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
 "uqB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch{
-	pixel_x = -26
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_access_txt = "null";
+	req_one_access_txt = "25;26;35;28"
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "url" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/effect/turf_decal/tile/neutral{
@@ -76690,6 +79573,11 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port)
+"ust" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/carpet,
+/area/service/bar)
 "usx" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
@@ -76792,20 +79680,10 @@
 /turf/open/floor/wood,
 /area/service/library)
 "uvn" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck{
-	pixel_y = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/item/ashtray{
-	name = "candle holder";
-	pixel_y = 15
-	},
-/obj/item/candle{
-	pixel_y = 21
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/service/bar)
 "uvz" = (
@@ -76830,19 +79708,10 @@
 /area/command/heads_quarters/hop)
 "uwx" = (
 /obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4
 	},
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/sign/barsign{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/service/bar)
 "uwH" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -76867,10 +79736,20 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/security/office)
-"uyl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"uyk" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"uyl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -76881,27 +79760,27 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "uyq" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = -28
+/obj/structure/table,
+/obj/item/storage/bag/plants,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
 	},
-/obj/item/lipstick/black,
-/obj/item/lipstick/jade{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/obj/item/lipstick/purple{
-	pixel_x = -2;
-	pixel_y = -2
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/area/hallway/secondary/service)
 "uyH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -76919,13 +79798,15 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "uzY" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/service/bar)
+"uAo" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "uBW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -77010,15 +79891,15 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "uEC" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
 /obj/structure/railing,
+/obj/effect/turf_decal/bot,
 /obj/vehicle/ridden/grocery_cart{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "uED" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -77083,8 +79964,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -77092,8 +79976,20 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/fluff/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
@@ -77102,7 +79998,6 @@
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/hos)
 "uHq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -77116,6 +80011,7 @@
 	id = "Deliveries Gates";
 	name = "Deliveries Shutters"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "uIA" = (
@@ -77218,35 +80114,19 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "uLG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "uMQ" = (
-/obj/machinery/camera{
-	c_tag = "Bar"
+/obj/structure/sink/kitchen{
+	pixel_y = 28
 	},
-/obj/machinery/requests_console{
-	department = "Bar";
-	departmentType = 2;
-	pixel_y = 30;
-	receive_ore_updates = 1
-	},
-/obj/structure/table,
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/reagent_containers/rag{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/service/bar)
+"uNl" = (
+/obj/structure/trash_pile,
+/turf/open/space/basic,
+/area/space)
 "uOc" = (
 /obj/effect/landmark/start/captain,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -77322,7 +80202,7 @@
 	id_tag = "Toilet3";
 	name = "Unit 3"
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "uRL" = (
 /obj/structure/window/reinforced{
@@ -77332,9 +80212,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "uRM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -77379,6 +80256,20 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solars/port/fore)
+"uUm" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	dir = 1;
+	req_access_txt = "47"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "uUx" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -77400,13 +80291,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_x = -8;
-	pixel_y = 12
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
@@ -77442,6 +80334,13 @@
 	dir = 4
 	},
 /area/service/hydroponics/garden)
+"uVG" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "uVQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -77485,6 +80384,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
+"uWx" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "uWO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -77507,13 +80417,7 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "uXT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -77525,6 +80429,9 @@
 /obj/item/stock_parts/subspace/analyzer,
 /obj/machinery/light_switch{
 	pixel_y = 26
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tcomms)
@@ -77538,8 +80445,15 @@
 /turf/open/floor/catwalk_floor,
 /area/engineering/main)
 "uYk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -77603,6 +80517,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
+"vad" = (
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Auxiliary Bathrooms"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/commons/toilet/auxiliary)
 "vaA" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -77693,6 +80623,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"vdh" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "vdw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/solars/port/aft";
@@ -77769,6 +80709,21 @@
 	},
 /turf/open/floor/carpet,
 /area/service/chapel/main)
+"veB" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "veI" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood,
@@ -77838,6 +80793,13 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/commons/locker)
+"vfO" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "vfZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -77886,9 +80848,17 @@
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
 "vhg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/obj/machinery/camera{
+	c_tag = "Club - Fore";
+	pixel_y = 12
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/service/bar)
 "vhj" = (
 /obj/structure/cable/yellow{
@@ -77914,6 +80884,9 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "vhM" = (
@@ -77927,7 +80900,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "viK" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -78055,13 +81028,17 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "vls" = (
-/obj/machinery/door/airlock{
-	id_tag = "AuxToilet3";
-	name = "Unit 3";
-	dir = 4
+/obj/structure/closet,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/structure/fluff/railing{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/commons/toilet/auxiliary)
+/area/maintenance/port)
 "vmb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
@@ -78168,18 +81145,8 @@
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "vqd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/bottle/vodka{
-	pixel_x = -2;
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/service/bar)
 "vqv" = (
 /obj/structure/table/wood,
@@ -78197,20 +81164,20 @@
 /turf/open/floor/plasteel/dark,
 /area/command/gateway)
 "vre" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_y = -26
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "vrr" = (
 /obj/structure/disposalpipe/segment{
@@ -78276,7 +81243,7 @@
 	id_tag = "Toilet2";
 	name = "Unit 2"
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "vsV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -78311,6 +81278,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
+"vuf" = (
+/obj/machinery/door/airlock{
+	dir = 8;
+	id_tag = "Toilet1";
+	name = "Unit 1"
+	},
+/turf/open/space/basic,
+/area/commons/toilet/auxiliary)
 "vvt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78429,10 +81404,6 @@
 	c_tag = "Telecomms - Storage";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tcomms)
 "vyZ" = (
@@ -78471,6 +81442,13 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"vAQ" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "researchrangeshutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/misc_lab/range)
 "vBd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78487,12 +81465,16 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "vBv" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
 	},
-/turf/open/floor/plasteel,
+/obj/item/storage/fancy/donut_box,
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
 /area/service/bar)
 "vBW" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
@@ -78502,7 +81484,7 @@
 /area/engineering/atmos)
 "vCd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "vCf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78530,8 +81512,10 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "vCi" = (
-/obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -78608,20 +81592,21 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "vEl" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 8;
-	freq = 1400;
-	location = "Bar"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/area/service/bar)
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
+"vFs" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "vFz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78666,11 +81651,16 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "vGk" = (
 /obj/machinery/power/terminal,
@@ -78715,6 +81705,14 @@
 	},
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
+"vHC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "vHG" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -78733,6 +81731,19 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"vIX" = (
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_access_txt = "null";
+	req_one_access_txt = "25;26;35;28"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "vJf" = (
 /obj/machinery/door/airlock{
 	dir = 8;
@@ -78745,13 +81756,16 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "vJE" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/chem_master/condimaster{
-	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
-	name = "BrewMaster 2199";
-	pixel_x = -4
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "trim"
+	},
+/turf/open/floor/carpet/black,
 /area/service/hydroponics)
 "vKw" = (
 /obj/structure/cable/yellow{
@@ -78846,6 +81860,18 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/deepfryer,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -78924,6 +81950,29 @@
 	dir = 4
 	},
 /area/cargo/storage)
+"vOi" = (
+/obj/structure/toilet{
+	pixel_y = 18
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/machinery/button/door{
+	id = "AuxToilet1";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/obj/machinery/newscaster{
+	pixel_x = -26;
+	pixel_y = -2
+	},
+/obj/item/soap/nanotrasen,
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "vOr" = (
 /obj/machinery/meter,
 /obj/structure/grille,
@@ -78966,10 +82015,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
+"vPT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "vQX" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "vRu" = (
 /obj/machinery/meter,
@@ -79015,8 +82084,20 @@
 /area/commons/dorms)
 "vSG" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -79032,12 +82113,8 @@
 /turf/closed/wall/r_wall,
 /area/space)
 "vTo" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/sign/poster/random{
+	pixel_x = 32
 	},
 /turf/open/floor/carpet,
 /area/service/bar)
@@ -79098,6 +82175,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/commons/fitness/recreation)
+"vVw" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "vWf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -79109,18 +82194,17 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "vWi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/service/kitchen)
@@ -79149,16 +82233,19 @@
 /turf/closed/wall,
 /area/service/kitchen)
 "vXa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "rdprivacy";
 	name = "privacy shutter"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
@@ -79218,6 +82305,18 @@
 	pixel_x = 6;
 	pixel_y = 26
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/service/kitchen)
 "vZd" = (
@@ -79253,6 +82352,20 @@
 	dir = 1
 	},
 /area/commons/fitness/recreation)
+"vZs" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/experimentor,
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "vZw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -79291,20 +82404,20 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "waL" = (
-/obj/structure/table,
-/obj/item/clothing/head/hardhat/cakehat,
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "waU" = (
 /obj/machinery/power/apc{
@@ -79345,40 +82458,32 @@
 	},
 /area/commons/fitness/recreation)
 "wbK" = (
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_y = 3
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Hydroponics Delivery";
+	req_access_txt = "35"
 	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 8;
-	pixel_y = 8
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	dir = 8;
+	freq = 1400;
+	location = "Hydroponics"
 	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/item/watertank,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/item/grenade/chem_grenade/antiweed,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/delivery,
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "wbZ" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	pixel_y = 12
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/service/bar)
 "wcj" = (
 /obj/structure/cable/yellow{
@@ -79483,7 +82588,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "weN" = (
 /obj/structure/cable/yellow{
@@ -79518,24 +82623,19 @@
 /turf/open/floor/carpet,
 /area/service/chapel/main)
 "wfY" = (
-/obj/machinery/light/small{
+/obj/structure/table,
+/obj/item/camera_film,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "AuxToilet1";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/structure/toilet{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/commons/storage/art)
 "wgf" = (
 /obj/item/kirbyplants,
 /turf/open/floor/plasteel/dark/side,
@@ -79545,7 +82645,10 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "wgD" = (
-/obj/structure/chair/sofachair{
+/obj/structure/sign/poster/random{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -79609,9 +82712,9 @@
 	},
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
+	dir = 4;
 	name = "Security External Airlock";
-	req_access_txt = "1";
-	dir = 4
+	req_access_txt = "1"
 	},
 /turf/open/floor/plating,
 /area/security/prison)
@@ -79633,7 +82736,7 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "wjR" = (
 /turf/open/floor/carpet/red,
@@ -79666,11 +82769,11 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "wlF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
 	},
-/area/service/kitchen)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wlH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -79713,10 +82816,15 @@
 	name = "Toxins Storage APC";
 	pixel_y = 25
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = -12;
+	pixel_y = 12
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel,
 /area/science/storage)
 "wmK" = (
@@ -79785,7 +82893,7 @@
 	name = "old sink";
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "wnk" = (
 /obj/structure/table,
@@ -79802,6 +82910,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/command/teleporter)
+"woc" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
 "wol" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -79815,17 +82938,20 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "wox" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/newscaster{
+	pixel_x = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/sign/plaques/deempisi{
+	pixel_y = 28
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
+/area/service/bar)
 "woJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -79851,11 +82977,14 @@
 /turf/open/space,
 /area/solars/starboard/aft)
 "wpo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engineering/storage/tcomms)
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/bar)
 "wpz" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -79883,10 +83012,18 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "wpE" = (
-/obj/machinery/smartfridge/drinks{
-	icon_state = "boozeomat"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
 	},
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "wqi" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -80026,14 +83163,23 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "wtU" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "wud" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -80067,14 +83213,19 @@
 /turf/open/floor/plasteel/yellowsiding,
 /area/commons/fitness/recreation)
 "wuS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tcomms)
+"wvv" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "wvO" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/genetics";
@@ -80159,13 +83310,13 @@
 /area/ai_monitored/command/storage/eva)
 "wxA" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "wxF" = (
@@ -80311,11 +83462,26 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
 "wBL" = (
-/obj/machinery/vending/hydronutrients,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/structure/noticeboard{
+	desc = "A board for pinning important notices upon. Probably helpful for keeping track of requests.";
+	name = "requests board";
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "wBP" = (
@@ -80355,14 +83521,29 @@
 /obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "wCs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -80375,7 +83556,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "wCV" = (
 /obj/machinery/light{
@@ -80431,17 +83612,29 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
 "wEG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/commons/toilet/auxiliary)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/commons/storage/art)
 "wEJ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/airalarm{
@@ -80493,15 +83686,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "wFH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/landmark/blobstart,
 /turf/open/floor/catwalk_floor,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "wFX" = (
 /turf/open/space/basic,
 /area/ai_monitored/aisat/exterior)
@@ -80515,10 +83705,18 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "wGq" = (
-/obj/machinery/computer/slot_machine{
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
 	},
-/turf/open/floor/carpet,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/service/bar)
 "wGv" = (
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
@@ -80639,7 +83837,7 @@
 /area/engineering/atmos)
 "wKo" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/science/circuit)
 "wKu" = (
 /obj/machinery/light/small{
@@ -80712,6 +83910,13 @@
 	},
 /turf/open/floor/engine/cult,
 /area/service/library)
+"wMF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "wMJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Mix"
@@ -80769,6 +83974,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"wNR" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "wNX" = (
 /obj/machinery/air_sensor/atmos/oxygen_tank,
 /turf/open/floor/engine/o2,
@@ -80810,11 +84023,18 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "wPk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wPl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -80887,12 +84107,18 @@
 /area/cargo/office)
 "wQM" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/turf_decal/loading_area{
+	icon_state = "drain";
+	name = "drain"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "trim"
+	},
+/turf/open/floor/carpet/black,
 /area/service/hydroponics)
 "wQW" = (
 /obj/machinery/meter,
@@ -80902,11 +84128,17 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"wRs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/security/checkpoint/science/research)
 "wRy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "wRz" = (
@@ -80918,16 +84150,35 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "wRE" = (
-/obj/machinery/light/small,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/commons/toilet/auxiliary)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "wRK" = (
-/obj/effect/landmark/start/bartender,
-/turf/open/floor/wood,
-/area/service/bar)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4;
+	name = "Bar Maintenance";
+	req_access_txt = "25"
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard)
 "wSs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -80967,14 +84218,17 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "wST" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -81027,21 +84281,10 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "wUI" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
 	},
-/obj/structure/table/wood,
-/obj/item/ashtray{
-	name = "candle holder";
-	pixel_y = 4
-	},
-/obj/item/candle{
-	pixel_y = 10
-	},
-/obj/item/clothing/mask/cigarette/cigar{
-	pixel_x = 6
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/service/bar)
 "wUL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -81085,7 +84328,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/fluff/railing{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "wWO" = (
@@ -81165,23 +84412,14 @@
 	},
 /area/engineering/main)
 "wYd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/requests_console{
+	department = "Bar";
+	departmentType = 2;
+	pixel_y = 30;
+	receive_ore_updates = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj,
-/obj,
-/obj,
-/obj,
-/obj,
-/obj,
-/turf/open/floor/plasteel,
-/area/commons/storage/art)
+/turf/open/floor/wood,
+/area/service/bar)
 "wYi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/fitness/recreation";
@@ -81381,7 +84619,8 @@
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "xbM" = (
 /obj/structure/disposalpipe/segment,
@@ -81441,6 +84680,15 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"xdC" = (
+/obj/structure/mirror{
+	pixel_y = 34
+	},
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "xdX" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -81468,14 +84716,11 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "xet" = (
-/obj/structure/table,
-/obj/item/camera_film,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/commons/storage/art)
+/turf/open/floor/wood,
+/area/service/bar)
 "xeF" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -81556,20 +84801,19 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
 "xjs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/turf/closed/wall,
+/area/commons/storage/art)
 "xjY" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/service/library)
 "xkG" = (
-/obj/item/integrated_electronics/wirer,
-/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 20
+	},
 /turf/open/floor/plasteel/white,
-/area/science/circuit)
+/area/science/research)
 "xlc" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -29
@@ -81609,15 +84853,15 @@
 	},
 /area/cargo/sorting)
 "xlH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -81824,6 +85068,20 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"xqj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "xqv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -81866,6 +85124,13 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"xro" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "xrw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -81880,6 +85145,11 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
+"xrO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "xsc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -81960,6 +85230,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"xuf" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "toxins_blastdoor";
+	name = "biohazard containment door"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "xuF" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/beanbag/black{
@@ -82021,7 +85305,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -82032,6 +85315,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "xwj" = (
@@ -82085,6 +85370,26 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"xxO" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/service/kitchen)
 "xyp" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -82092,8 +85397,13 @@
 /turf/open/floor/carpet/purple,
 /area/maintenance/port/fore)
 "xze" = (
-/turf/closed/wall,
-/area/service/theater)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/item/kirbyplants/random,
+/turf/open/floor/carpet,
+/area/service/bar)
 "xzr" = (
 /obj/machinery/photocopier,
 /obj/machinery/power/apc{
@@ -82207,10 +85517,18 @@
 /turf/open/floor/catwalk_floor,
 /area/engineering/main)
 "xCx" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/xmastree,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/carpet,
 /area/service/bar)
 "xCC" = (
@@ -82248,24 +85566,31 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port)
 "xDD" = (
-/obj/machinery/door/airlock{
-	id_tag = "AuxShower";
-	name = "Shower"
+/obj/structure/table/wood/fancy/red,
+/obj/item/ashtray{
+	name = "candle holder"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/commons/toilet/auxiliary)
+/obj/item/reagent_containers/food/snacks/burger/bigbite{
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/carpet,
+/area/service/bar)
 "xDL" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
+/turf/open/floor/plasteel/white/side,
+/area/hallway/primary/central)
 "xDS" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
@@ -82328,9 +85653,12 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "xEM" = (
-/obj/structure/scale,
-/turf/open/floor/plating,
-/area/commons/toilet/auxiliary)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/port)
 "xFb" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
@@ -82530,15 +85858,29 @@
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
 "xKw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment{
+/obj/structure/chair/stool/bar,
+/obj/machinery/camera{
+	c_tag = "Bar";
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/bar";
+	dir = 1;
+	name = "Bar APC";
+	pixel_y = 25
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/service/bar)
 "xKG" = (
 /obj/machinery/door/firedoor,
@@ -82566,13 +85908,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "xLe" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe";
-	pixel_x = -4
+/obj/effect/spawner/lootdrop/keg,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/service/bar)
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xLg" = (
 /obj/structure/table,
 /obj/item/folder/red,
@@ -82603,6 +85944,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"xLQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "xLR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -82707,9 +86055,6 @@
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
 "xNY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -82725,7 +86070,7 @@
 /area/engineering/storage/tech)
 "xOe" = (
 /obj/structure/kitchenspike,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "xOk" = (
 /obj/structure/table/reinforced,
@@ -82774,7 +86119,7 @@
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "xPf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
 "xPm" = (
@@ -82830,6 +86175,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"xQs" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xQv" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -82900,13 +86250,20 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
-"xSU" = (
-/obj/machinery/camera{
-	c_tag = "Theatre - Stage";
-	dir = 1
+"xSS" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xSU" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/service/bar)
 "xTt" = (
@@ -83016,8 +86373,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "xVl" = (
-/turf/closed/wall,
-/area/hallway/secondary/service)
+/obj/structure/rack,
+/obj/item/extinguisher,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/mask/gas,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xVy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -83029,10 +86392,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
+"xVO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/turf/open/floor/plasteel,
+/area/science/circuit)
 "xVP" = (
-/obj/machinery/light,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -83142,14 +86515,32 @@
 /turf/open/floor/plasteel,
 /area/commons/dorms)
 "xYE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -83171,25 +86562,27 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "xYV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/chair/stool/brass,
-/turf/open/floor/wood,
+/obj/structure/chair/comfy/black,
+/turf/open/floor/carpet,
 /area/service/bar)
 "xZj" = (
-/obj/machinery/camera{
-	c_tag = "Theatre - Backstage";
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/item/clothing/mask/pig,
-/obj/item/bikehorn,
-/turf/open/floor/wood,
-/area/service/theater)
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "xZy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83250,6 +86643,15 @@
 	dir = 1
 	},
 /area/engineering/main)
+"ybo" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/toilet/auxiliary";
+	name = "Auxiliary Restrooms APC";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plasteel/showroomfloor,
+/area/commons/toilet/auxiliary)
 "ycy" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -83444,11 +86846,24 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/item/stack/packageWrap,
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/item/stack/packageWrap,
-/obj/item/storage/box/donkpockets,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -83510,21 +86925,17 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "yhn" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/computer";
-	dir = 4;
-	name = "Telecomms Control Room APC";
-	pixel_x = 26
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 28
 	},
-/obj/machinery/computer/telecomms/server{
-	dir = 8;
-	network = "tcommsat"
+/obj/structure/table/wood/fancy/red,
+/obj/item/reagent_containers/food/snacks/pie/plump_pie{
+	pixel_x = 3;
+	pixel_y = 11
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/turf/open/floor/carpet,
+/area/service/bar)
 "yho" = (
 /obj/structure/chair/comfy/teal{
 	dir = 4
@@ -83584,12 +86995,9 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "ykI" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/service/hydroponics)
+/obj/machinery/iv_drip/feeding_tube,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "ylb" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -89879,7 +93287,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -90136,7 +93544,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -90391,11 +93799,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+lMJ
+bBj
+lMJ
+lMJ
 aaa
 aaa
 aaa
@@ -90650,7 +94058,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -90907,7 +94315,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -91164,10 +94572,10 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -91421,11 +94829,11 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+bBj
+lMJ
 aaa
 aaa
 aaa
@@ -91678,10 +95086,10 @@ aaa
 aaa
 aaa
 aaa
+lMJ
 aaa
 aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -91933,13 +95341,13 @@ aaf
 aaf
 aaa
 aaa
-aaa
-aaa
+lMJ
+lMJ
+lMJ
 aaf
 aaf
 aaf
-aaf
-aaf
+ake
 aaa
 aaa
 aaa
@@ -92194,8 +95602,8 @@ aaa
 aaa
 aaf
 aaa
-aaa
-aaa
+lMJ
+lMJ
 aaf
 aaf
 aaf
@@ -92207,7 +95615,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+lMJ
 aaf
 aaf
 aaf
@@ -92449,24 +95857,24 @@ aaa
 aaa
 aaa
 aaa
+lMJ
+aaa
+lMJ
+aaa
+aaa
+aaf
+aaa
+aaf
+aaa
+aaa
 aaa
 aaa
 aaa
 aaa
 aaa
 aaf
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-aaa
+ake
+lMJ
 aaa
 aaa
 aaf
@@ -92712,17 +96120,17 @@ aRA
 aVs
 aVs
 aVs
-aVs
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaf
-aVs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
 aVs
 aVs
 aVs
@@ -92979,7 +96387,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+lMJ
 aVs
 btO
 aWT
@@ -92991,10 +96399,10 @@ aaa
 aaa
 aVs
 btO
-aWT
+qIa
+aRA
 aVs
-aVs
-aVs
+aRA
 aaa
 aaa
 aaa
@@ -93240,7 +96648,7 @@ aaa
 aYC
 aVu
 aWU
-aRA
+aYC
 aaa
 aaa
 aaa
@@ -93250,7 +96658,7 @@ aRA
 btS
 aWU
 bOd
-bPA
+aZZ
 dYu
 aaa
 aaa
@@ -93741,6 +97149,7 @@ cZf
 aWV
 aRA
 aaa
+lMJ
 aaa
 aaa
 aaa
@@ -93748,13 +97157,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+lMJ
 aaa
 aRA
 bvC
 bxt
-aYC
+aRA
 aaa
 aaa
 aaa
@@ -93762,10 +97170,10 @@ aaa
 aaa
 aYC
 bKT
-aWU
+xQs
+aYC
 aVs
-aVs
-aVs
+aRA
 aaa
 aaa
 aaa
@@ -93996,19 +97404,19 @@ aaf
 hXW
 aVx
 aWU
+aRA
 aVs
+aRA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aRA
 aVs
-aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
-aVs
-aVs
+aRA
 bvD
 aWU
 aVs
@@ -94275,9 +97683,9 @@ aaa
 aaa
 aaa
 aRA
-aVu
-aWU
-aVs
+elv
+jyY
+aRA
 aaf
 aaf
 aaa
@@ -94510,20 +97918,20 @@ aSJ
 aDb
 aVy
 aWU
+aRA
 aVs
+aRA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aRA
 aVs
-aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
-aVs
-aVs
-aVu
+aRA
+fwb
 bxv
 aVs
 aaa
@@ -94533,8 +97941,8 @@ aaa
 aaa
 aVs
 aVu
-bMu
-aRA
+aWU
+aVs
 aaa
 aaf
 aaa
@@ -94779,8 +98187,8 @@ aaa
 aaa
 aVs
 bsl
-btO
-bvE
+aVu
+bvF
 bxw
 aVs
 aaa
@@ -95037,7 +98445,7 @@ aaa
 aVs
 bsm
 aVu
-bvF
+fCR
 bxw
 aVs
 aaa
@@ -95047,8 +98455,8 @@ aaa
 aaa
 aVs
 aVu
-bMw
-aRA
+bxw
+aVs
 aaa
 aaf
 aaa
@@ -95292,7 +98700,7 @@ aaa
 aaa
 aaa
 aVs
-baa
+bsm
 btP
 aWX
 bxx
@@ -95304,8 +98712,8 @@ aaa
 aaa
 aRA
 btS
-bxw
-aVs
+mQH
+aRA
 aaf
 aaf
 aaa
@@ -95550,7 +98958,7 @@ aaa
 aaa
 aVs
 bsn
-btQ
+aVu
 bvG
 bxw
 aVs
@@ -95562,7 +98970,7 @@ aaa
 aVs
 aVu
 bxw
-aRA
+aVs
 aaa
 aaf
 aaa
@@ -95795,26 +99203,26 @@ cYK
 cYQ
 aVB
 aWZ
+aRA
 aVs
+aRA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aRA
 aVs
-aVs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aVs
-aVs
-aVs
-bvH
+aRA
+ggA
 bxy
 hXW
 aaf
 bCG
 bEl
-aVs
+aRA
 aaf
 aRA
 bKV
@@ -95822,7 +99230,7 @@ bMx
 aRA
 aaa
 aaf
-aaa
+uNl
 aaa
 aaa
 aaa
@@ -96069,9 +99477,9 @@ bvH
 bMw
 aRA
 aVs
-aVs
+aRA
 bEm
-aVs
+aRA
 aVs
 aRA
 btS
@@ -96309,9 +99717,9 @@ aSM
 aDb
 cZq
 aWZ
-aVs
-aVs
-aVs
+aRA
+aRA
+aRA
 aaa
 aaa
 aaa
@@ -96319,23 +99727,23 @@ aaa
 aaa
 aaa
 aaa
-aVs
-aVs
-aVs
+aRA
+aRA
+aRA
 bBl
 bxz
 aRA
 bBc
-aVs
+aRA
 sIA
-aVs
+aRA
 bHH
 aRA
-aVu
+bvF
 bMz
-bOe
+alK
 bPC
-bRc
+amU
 alK
 aaf
 aaf
@@ -96581,18 +99989,18 @@ aVs
 btR
 bvI
 bxA
-bCN
-bbI
-bbI
-bbI
-bbI
-bbI
+nWb
+qJk
+uhi
+qJk
+qJk
+qJk
 nWb
 btT
 bMA
-alK
+kXk
 bPD
-asa
+smm
 alK
 aaa
 aaa
@@ -96840,7 +100248,7 @@ bvJ
 bxB
 bCQ
 bCH
-bCH
+upD
 bEn
 dic
 bHI
@@ -96848,7 +100256,7 @@ bJo
 bKW
 bMB
 alK
-dio
+oOU
 asa
 alK
 bTn
@@ -97097,11 +100505,11 @@ bvK
 bxC
 oVF
 eSb
-aRA
-aRA
-aRA
+vEl
+nya
+oVF
 alK
-dQg
+alK
 alK
 alK
 alK
@@ -97352,13 +100760,13 @@ bso
 bso
 bvL
 bxD
-bzw
+vQX
 tre
 bCI
 bEo
-bJj
-bbL
-bJq
+aRA
+oRg
+bSw
 bbL
 ckl
 bbL
@@ -97613,9 +101021,9 @@ vQX
 bNd
 bCJ
 tUa
-aRA
-dio
-aob
+tEO
+nXX
+kly
 alC
 aqK
 aqO
@@ -97866,14 +101274,14 @@ baE
 baE
 bqd
 nhy
-vQX
-bNd
-bNd
+aRA
+qPs
+qPs
 sZN
 aRA
-amZ
+aUo
 aob
-aob
+jNy
 aob
 aob
 bPH
@@ -98124,9 +101532,9 @@ ajs
 jBe
 pHS
 vQX
-bNd
-bNd
-bNd
+jUo
+jUo
+sZN
 kYv
 kYv
 kYv
@@ -98370,7 +101778,7 @@ doJ
 bbK
 bcZ
 beN
-bgy
+bgA
 biz
 bka
 blX
@@ -98383,7 +101791,7 @@ rbE
 vQX
 jUo
 uEC
-pDn
+sZN
 kYv
 qUY
 igf
@@ -98638,7 +102046,7 @@ aeD
 kQP
 rNX
 kYv
-upD
+kYv
 kYv
 kYv
 kYv
@@ -98648,7 +102056,7 @@ fmJ
 efp
 wul
 kYv
-auF
+aob
 bSo
 alK
 bJs
@@ -98905,7 +102313,7 @@ yfu
 lZv
 uIN
 kYv
-ahe
+aoa
 bSo
 alK
 bUR
@@ -100179,13 +103587,13 @@ bsv
 btZ
 bvV
 bxN
-mei
+nJo
 nzp
 xEM
-mei
-smm
-iYz
-mei
+xEM
+cBE
+aob
+alK
 bLb
 bME
 bOi
@@ -100433,16 +103841,16 @@ icr
 bnU
 bql
 bsw
-baE
-kje
-ePg
-mei
-nzp
 xjs
-xDD
+kje
+kje
+xjs
+xjs
+xjs
+alK
 iZl
 nWX
-mei
+alK
 bLc
 aod
 aGN
@@ -100690,16 +104098,16 @@ icr
 faU
 bBG
 bsx
-bua
+kje
 mei
 jKl
 ubJ
 htO
-lrJ
-mei
-mei
-mei
-mei
+xjs
+ugb
+kFZ
+aob
+alK
 bLd
 aof
 aob
@@ -100946,17 +104354,17 @@ mKn
 kKH
 aoN
 bqn
-bsy
-bub
+cPP
+xjs
 hyy
 wEG
 nfs
 hVs
-jQR
-hVs
-rqx
-wRE
-mei
+xjs
+dio
+kFZ
+aob
+alK
 bLe
 bMF
 apz
@@ -101205,15 +104613,15 @@ bnX
 bqo
 bsz
 buc
-mei
+ghl
 dkr
-mei
+ozV
 nry
-mei
-qPs
-mei
+xjs
+aob
+kFZ
 vls
-mei
+alK
 bLf
 bJs
 aLd
@@ -101461,16 +104869,16 @@ iyy
 bnY
 bql
 bsA
-baE
-mei
-mei
-mei
+xjs
+gFi
+kmP
+pzY
 wfY
-mei
+xjs
 qgb
-mei
+kFZ
 etM
-mei
+alK
 bLg
 bLf
 amU
@@ -101718,16 +105126,16 @@ icr
 bnZ
 bql
 bsB
+xjs
+xjs
+xjs
+xjs
+xjs
+xjs
 alK
-aoe
-bxS
-mei
-mei
-mei
-mei
-mei
-mei
-mei
+iVb
+alK
+alK
 alK
 alK
 alK
@@ -101977,15 +105385,15 @@ bqp
 bsC
 bud
 bvY
-bxT
-bzC
-bPM
+czs
+czs
+cBs
 dCW
-gGc
-alC
+cBC
+hIc
 bSw
-bPM
-bPM
+uJU
+uJU
 bzC
 uJU
 uJU
@@ -102239,8 +105647,8 @@ alC
 bBq
 apz
 bOf
-bzC
-bSp
+bJE
+ceZ
 aoa
 aqO
 bMG
@@ -103775,7 +107183,7 @@ lxd
 bql
 awL
 glc
-fEX
+gGc
 fEX
 wtF
 exO
@@ -105584,7 +108992,7 @@ vWI
 glc
 buf
 cVh
-aVW
+cVh
 glc
 glc
 glc
@@ -105825,14 +109233,14 @@ fdl
 bfh
 bdx
 cIk
-bkx
+aYU
 aYU
 boj
 bqy
 bsK
-buj
+bky
 bwh
-bxY
+buj
 bzI
 buj
 bCW
@@ -105842,9 +109250,9 @@ cVd
 buj
 buj
 buj
-bxY
 buj
-bwh
+buj
+ieX
 bSD
 buj
 buj
@@ -106077,19 +109485,19 @@ rPB
 aXw
 aYV
 baG
-baG
+buk
 bdy
 baG
 baG
 baG
-bdP
+baG
 baG
 bok
 bqz
 bsL
 buk
 dCH
-bdP
+baG
 baG
 baG
 bCX
@@ -106099,9 +109507,9 @@ bHW
 baG
 baG
 baG
+baG
+baG
 bdP
-baG
-baG
 baG
 bTE
 bUZ
@@ -106339,14 +109747,14 @@ bdz
 bfi
 bfi
 bfi
-bky
+bfi
 bmn
 bfi
 bqA
-bqA
+bdO
 bul
 bfi
-bky
+bfi
 bGw
 bfi
 bCY
@@ -106354,9 +109762,9 @@ bEC
 bHX
 bHX
 bJC
-bHX
+nQA
 bMR
-bOn
+bHX
 bPY
 bRo
 bHX
@@ -106600,8 +110008,8 @@ pBK
 pBK
 gZR
 cml
+bkx
 pBK
-hPI
 pBK
 pBK
 bzJ
@@ -107372,7 +110780,7 @@ ucX
 vDn
 rcc
 dSO
-gBI
+bxY
 pVV
 pBK
 bzM
@@ -108160,9 +111568,9 @@ ijr
 ijr
 jxm
 bTK
-aZa
+cuH
 bWn
-bXL
+ciV
 bXL
 cah
 cbS
@@ -108419,8 +111827,8 @@ jmy
 bTL
 aYX
 bWj
-bXM
-bZa
+bXX
+clV
 cai
 cbT
 cdy
@@ -108678,7 +112086,7 @@ bVb
 bWo
 bXN
 bZb
-caj
+cca
 cbU
 cdz
 ceE
@@ -108934,7 +112342,7 @@ bTI
 bVc
 aXR
 bXN
-bZa
+bZb
 cak
 cbV
 cdA
@@ -108976,12 +112384,12 @@ cNK
 cOq
 cLm
 cLm
-cLm
-cMf
-cQK
+ieo
+wvv
+dPw
+cPb
 cPv
-cPv
-cPv
+cPb
 aaa
 aaa
 aaa
@@ -109192,7 +112600,7 @@ bVd
 bWp
 bXO
 bZc
-cal
+pPj
 cbW
 cdB
 ceG
@@ -109233,9 +112641,9 @@ cNL
 cgn
 cOT
 cLm
-cPP
+cPQ
 cQo
-cQL
+cQK
 cQY
 cQK
 kzn
@@ -109449,7 +112857,7 @@ aYZ
 bWq
 bXP
 bZd
-cam
+cdA
 cbX
 cdC
 ceH
@@ -109492,10 +112900,10 @@ cOU
 dDG
 cPQ
 cMf
-cQK
+oiS
+cPb
 cPv
-cPv
-cPv
+cPb
 aaa
 aaa
 aaa
@@ -109703,11 +113111,11 @@ ekt
 vCw
 bTG
 aYX
-aXR
-bXN
-bZa
+caT
+ckk
+cdw
 can
-cbY
+cca
 dDo
 ceJ
 cfY
@@ -109962,7 +113370,7 @@ bTG
 aYX
 aXR
 bXQ
-bZb
+cdw
 cao
 cbZ
 cdD
@@ -110477,7 +113885,7 @@ aYX
 aXL
 bXR
 bZe
-bZb
+bZa
 ccb
 cdF
 bZa
@@ -110511,19 +113919,19 @@ cHM
 ctH
 cPb
 cKC
-cLr
-cLm
-cLm
-cLm
-cLm
-cOq
-cLm
-cPQ
-cMf
-cQK
+ojy
+kTF
+hnj
+kTF
+kTF
+wMF
+kTF
+fcO
+pXo
+wNR
+cPb
 cPv
-cPv
-cPv
+cPb
 aaa
 aaa
 aaa
@@ -110739,12 +114147,12 @@ caq
 cdG
 caq
 cgb
-chg
-chg
-chg
+cOJ
+nEH
+cOJ
 clx
 cmD
-cnN
+coZ
 coZ
 coZ
 crF
@@ -110769,13 +114177,13 @@ cIE
 cJE
 cKD
 cLs
-cMh
+cLm
 cMW
-cMh
+cLm
 iUN
-cOY
-cPs
-cPU
+cOq
+cOT
+cLm
 cQp
 cQN
 cQY
@@ -110986,28 +114394,28 @@ kQh
 vss
 rye
 vCw
-bTP
+coa
 bVh
 bWu
 bTB
 bZg
-car
-car
+vVw
+wRE
 cdH
 ceL
-ceL
-ceL
-ceL
-ceL
-ceL
-ceL
+uWx
+cnO
+cnO
+cnO
 cnO
 ceL
+fdm
+cnO
 ceL
 crG
 csK
-ctF
-car
+qGT
+aPf
 car
 car
 cxA
@@ -111032,12 +114440,12 @@ cNO
 cOt
 cOZ
 cPt
-cLm
-cMf
+tbs
+uyk
 cQO
+cPb
 cPv
-cPv
-cPv
+cPb
 aaa
 aaa
 aaa
@@ -111249,22 +114657,22 @@ bWv
 bXT
 bZh
 cas
-cas
+xSS
 cdI
 cas
 cgc
-chh
-chh
-chh
+vFs
+vFs
+vFs
 cly
 cmE
+vdh
 cnP
-cpa
-cpa
+cnP
 crH
 csL
-ctG
-cgc
+spp
+bze
 cvG
 chh
 cxB
@@ -111285,13 +114693,13 @@ cKF
 cLu
 cMj
 cMY
-cMT
+sSy
 cOu
 cPa
 cPu
 cPV
 cQq
-cQP
+cQK
 cQY
 cRt
 kzn
@@ -111500,14 +114908,14 @@ opx
 hgE
 hFD
 nDn
-bTP
+nLm
 aYX
 aXP
 bXU
 bZi
-bZk
+bZj
 ccc
-ccc
+fbe
 bZj
 cgd
 cge
@@ -111515,7 +114923,7 @@ cgd
 cge
 cgd
 cgd
-cnQ
+cpb
 cpb
 cqv
 cgd
@@ -111545,13 +114953,13 @@ cMZ
 cNP
 cOv
 cPb
-cPv
+oKW
 cPb
-cPv
+vad
+oKW
 cPb
-cPv
-cPv
-cPv
+cPb
+cPb
 aaa
 aaa
 aaa
@@ -111764,7 +115172,7 @@ bgZ
 bZj
 cat
 ccd
-ccd
+vPT
 ceN
 cgd
 chi
@@ -111802,13 +115210,13 @@ cNa
 cNQ
 cOw
 cPb
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaf
+oFP
+knh
+mhW
+lwe
+oQX
+dNQ
+lwe
 aaa
 aaa
 aaa
@@ -112015,17 +115423,17 @@ qur
 jra
 szz
 bTS
-aYX
-aXR
+bVb
+sNj
 bXW
-bZk
+bZn
 cau
-cce
-ccd
-qBh
+ohK
+cdJ
+uRM
 cgd
 chj
-ciC
+cjY
 cjY
 clA
 cmF
@@ -112058,14 +115466,14 @@ cPb
 cNb
 cLm
 cOx
-cPc
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+cPb
+xdC
+xrO
+mSS
+pqt
+hwx
+nHw
+lwe
 aaa
 aaa
 aaa
@@ -112271,11 +115679,11 @@ qka
 mxh
 lMS
 vCw
-bTS
-aYX
-aXR
+cqG
+lwN
+tCA
 bXV
-bZj
+bZn
 cav
 ccf
 dDp
@@ -112284,13 +115692,13 @@ cgd
 chk
 ciD
 cjZ
-clB
+mjJ
 cmG
-cnT
+clB
 cpe
 cqy
 cgd
-csO
+csP
 diL
 cuD
 cvH
@@ -112315,14 +115723,14 @@ cPb
 cNc
 cNR
 cOy
-cPd
-aaa
-aaa
-aaf
-aaa
-aaa
-aaf
-aaa
+cPb
+xdC
+knh
+giL
+ayl
+rTi
+ybo
+lwe
 aaa
 aaa
 aaa
@@ -112529,26 +115937,26 @@ eGP
 eGP
 lJx
 bTT
-aYX
-bWy
+oao
+bWB
 bXX
 bZl
-caw
-ccg
+ohK
+ohK
 cdJ
-ceQ
+coe
 cge
-chk
+cvM
 ciE
 cka
-clC
+mwN
 cmH
 cnU
 cpf
 cqz
 cgd
 csP
-bTs
+ctJ
 cuE
 cvH
 cwJ
@@ -112573,13 +115981,13 @@ cNd
 cNS
 cOz
 cPb
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
+lwe
+vuf
+lwe
+lvV
+lwe
+mdr
+lwe
 aaa
 aaa
 aaa
@@ -112787,10 +116195,10 @@ tOg
 lJx
 eMh
 bVl
-bWz
+bWB
 bXY
 bZm
-cax
+ohK
 cch
 cdK
 uRM
@@ -112805,7 +116213,7 @@ cpg
 cqA
 crI
 csQ
-ctL
+clK
 ctL
 ctL
 ctL
@@ -112830,13 +116238,13 @@ cPb
 cPb
 cPb
 cPb
-aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-aaa
+vOi
+knh
+lwe
+sYw
+lwe
+qJq
+lwe
 aaa
 aaa
 aaa
@@ -113045,12 +116453,12 @@ lJx
 bTV
 bVm
 bWA
-bXV
-bZj
+xDL
+fAn
 cay
 cci
 cdL
-ceR
+cJQ
 izu
 chm
 ciG
@@ -113062,8 +116470,8 @@ cph
 cqB
 cJm
 csR
+kgF
 ctL
-cuF
 cvJ
 cwK
 cxH
@@ -113081,19 +116489,19 @@ cHS
 cIN
 cJM
 cCq
-cxL
+saa
 cmk
 gNe
-cwc
+bTs
 cNT
-pSX
-ack
-ack
-aaf
-aaf
-aaa
-aaf
-aaa
+bTs
+lwe
+lwe
+lwe
+lwe
+lwe
+lwe
+lwe
 aaa
 aaa
 aaa
@@ -113300,30 +116708,30 @@ bBk
 lyF
 lJx
 bTW
-dCE
-bWA
-bXV
-bZk
-caz
-cci
+qSJ
+wlF
+bXY
+bZm
+ohK
+nCa
 cdM
 ceS
 cgg
 cgd
+lyL
 cgd
-ckd
+lyL
 cgd
-cgd
-cnX
+tpK
 cIm
-cnX
+tpK
 cgd
 csS
 ctM
-cuG
-cvK
-cuG
-cxH
+ctL
+cwL
+dvz
+tvw
 cyu
 czm
 cAq
@@ -113338,18 +116746,18 @@ cHT
 cFh
 cFh
 cKH
-cLz
+cLy
 wFH
 bqv
-bTs
-bTs
-bTs
+rwh
+fFA
+jkX
+lMJ
+lMJ
+lMJ
+lMJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -113557,12 +116965,12 @@ noS
 tIF
 lJx
 bTX
-aYX
+ecA
 bWB
-bXZ
-bZj
+bXX
+erw
 caA
-ccj
+ohK
 cdN
 ceT
 cgh
@@ -113576,12 +116984,12 @@ cpj
 cqC
 cgo
 cLB
+mBn
 ctL
-cuH
 cuG
-cwL
+lPv
 cxI
-cyu
+hvi
 czn
 cAr
 cBl
@@ -113599,15 +117007,15 @@ bSt
 cMl
 cJl
 bTs
+bTs
+bTs
 aaf
-aaf
-aaf
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+lMJ
+lMJ
+bBj
+lMJ
 aaa
 aaa
 aaa
@@ -113814,12 +117222,12 @@ dPX
 jdL
 lJx
 bTY
-aZa
+rSO
 bWC
-bSS
+bXV
 bZn
 caB
-ccj
+anR
 cdO
 ceU
 cgi
@@ -113828,16 +117236,16 @@ ciI
 ckf
 clG
 dbI
-cnZ
+cIQ
 cpk
 cqD
 cgo
 csU
+clK
 ctL
-ctL
+vAQ
 cvL
-ctL
-ctL
+cvL
 ctL
 cvL
 cAs
@@ -113858,12 +117266,12 @@ bTs
 bTs
 aaf
 aaa
+lMJ
+aaa
+lMJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -114070,31 +117478,31 @@ ott
 nMV
 tim
 oOi
-bTI
-aYX
-bWB
-aVU
+crS
+bXM
+cff
+jCO
 bZo
 bZo
 cck
 cdP
-bZo
+wRs
 bZo
 chp
 iTm
 eOP
 nyA
-bZn
-coa
+cgo
+cyx
 cpl
 cqE
-crK
+crM
 csV
 ctN
 cuI
-cvM
-cwM
-caw
+ohK
+ohK
+sUc
 cyv
 czo
 cAt
@@ -114119,9 +117527,9 @@ cRe
 cRe
 cRe
 cRe
-aaa
-aaa
-aaa
+lMJ
+bBj
+lMJ
 aaa
 aaa
 aaa
@@ -114327,10 +117735,10 @@ wzp
 med
 tim
 oOi
-bTI
-aYX
-bWB
-aVW
+crS
+ecA
+cff
+tsg
 bZo
 caC
 ccl
@@ -114341,17 +117749,17 @@ chq
 ciK
 ckh
 clI
-bZn
+cgo
 cob
 cpm
 cqF
-crL
+rvm
 csW
 ctO
 cuJ
 cvN
-dDy
-cwN
+hut
+fLC
 cyw
 czp
 cAu
@@ -114377,7 +117785,7 @@ cYT
 djg
 cRe
 aaa
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -114584,10 +117992,10 @@ rLS
 rvr
 wud
 oOi
-bTI
-aYX
-bWB
-aVW
+crS
+ecA
+cff
+tsg
 bZo
 caD
 ccm
@@ -114598,21 +118006,21 @@ chp
 aAk
 rTl
 abN
-cgo
-coc
+rIw
+ohK
 cpn
-cqG
+cqE
 crM
 csX
-ctP
+ohK
 cuK
 cvO
 cwO
 cxJ
-cyx
+cCs
 czq
 cAv
-cBp
+cCs
 cCs
 ctP
 cEp
@@ -114621,7 +118029,7 @@ cGi
 cHc
 cHY
 cIS
-cJQ
+fLY
 cgo
 cQs
 cQS
@@ -114841,37 +118249,37 @@ lJx
 bQx
 lJx
 eDZ
-bTJ
-aYX
+cuF
+rZs
 bWD
-bYa
+bSS
 bZo
 caE
 ccn
-cdS
-ceX
-cgl
+bZo
+bZo
+bZo
 chp
 gTs
 cki
 ijI
-cgo
-ccd
-cpo
+rIw
+ohK
+cpu
 cqH
 rrX
 pfi
-pfi
-kFZ
+irO
+rrX
 lja
-nSv
-nSv
-cyy
+rrX
+omw
+sJE
 czr
 cAw
 cBq
-cyy
-cyK
+xuf
+gCe
 cyK
 cAP
 cyK
@@ -115101,32 +118509,32 @@ bSP
 bUa
 bVn
 bWE
-bSS
-bZo
-bZo
-bZo
-bZo
-bZo
-bZo
-chp
-cgo
-cgo
-cgo
-cgo
-cod
-cpp
-cqI
+riH
+dvY
+dvY
+dvY
+dvY
+cpI
+fcj
+cwa
+cJa
+fFM
+mWb
+rIw
+ohK
+cpu
+ohK
 jiG
 kmT
 eTY
 ely
 oAS
 pgP
-nSv
-cyz
-czs
+rrX
+cCt
+czD
 cAx
-cFr
+czD
 cCt
 cyK
 cEq
@@ -115355,36 +118763,36 @@ bcg
 bcg
 bcg
 bcg
-bTS
-aYX
+thF
+nDv
 bWF
 bYb
-cmZ
+eum
 diA
-cJb
+bmG
 dDq
 ceY
 cgm
-chr
-ciM
-ckk
-clL
-cmM
-coe
+cgo
+cgo
+cgo
+cgo
+cgo
+xkG
 cpq
-cqJ
+ohK
 vXa
-sDM
+amA
 dvg
 sDM
 wST
 vjL
-nSv
+rrX
 cyA
 czt
 cAy
-cBs
-cCt
+cFr
+gVf
 cyK
 cEr
 cEr
@@ -115586,8 +118994,8 @@ aWp
 aXS
 aYX
 baZ
+buL
 bcl
-bdO
 bfE
 bhA
 bjl
@@ -115597,50 +119005,50 @@ boJ
 bra
 btj
 buL
-bdO
+hIO
 byv
 bcl
 bBQ
 bDz
 bFg
-bGV
-bGV
+cMa
+bUb
 bKc
 bLH
 bNt
 bOO
 bQz
 bRO
-bSQ
 bUb
-bVb
+bUb
+ghF
 bWG
 bSS
 bSS
 bSS
 bSS
-bSS
-csg
+dXY
+cqZ
 cgo
 cgo
-cgo
-cgo
+diB
+hPI
 clJ
-cmL
-cof
-cpr
-cci
+jIy
+ohK
+erp
+dXa
 nSv
 eXu
 hgy
 qIp
 jwE
 iGV
-nSv
+rrX
 cyB
 czy
 cAz
-cBt
+cCA
 cCu
 cyK
 cEs
@@ -115843,8 +119251,8 @@ aWq
 aXY
 aZr
 bba
-dCH
-bdP
+buk
+baG
 baG
 bhB
 bjm
@@ -115853,47 +119261,47 @@ aWf
 aWf
 brb
 btk
-aWf
+dQg
 bwI
-aWf
+llF
 dCT
 bBR
 bDA
 bFh
 bGW
-bIr
-bwI
-aWf
-aWf
-aWf
-aWf
-dCT
-aWf
-aWf
+iRz
+iRz
+cnQ
+cnX
+cnX
+cnX
+pcx
+cnX
+cnX
 bVo
 bWH
 bYc
 bZq
 caG
-abt
 bSS
-csg
+bSS
+crX
 cgo
 pbc
 iAD
-cgo
-cgo
-cgo
+klH
+obb
+jIy
 ubH
-cpr
-cci
-nSv
+bna
+ohK
+rrX
 vGw
 qEi
 tjd
-jwE
+jgP
 eJd
-nSv
+rrX
 cyC
 czv
 dDA
@@ -116108,10 +119516,10 @@ bjn
 bkS
 bmK
 boK
-brc
+cMh
 brc
 buM
-bwJ
+byw
 byw
 byw
 byw
@@ -116119,38 +119527,38 @@ bDB
 bFi
 bGX
 bIs
-bKd
-bIs
 bNu
-bIs
-bIs
-bIs
+cnT
+qaz
+qaz
+qaz
+fsf
 bSR
 bUc
 bVp
 bWI
-bYd
-aWf
+bSS
+jin
 caH
 ccq
 bSS
 csg
 cgo
 chs
-ciO
+dlt
 ckm
 clN
-bZj
-cog
-cpr
+jIy
+okY
+cpu
 cqK
-nSv
+rrX
 gcz
 opM
 tkT
 rjg
 qda
-nSv
+rrX
 cyD
 czw
 cAA
@@ -116364,50 +119772,50 @@ bhD
 bjo
 bkT
 jIg
-hIO
-teZ
-jkm
-teZ
 wep
-sTt
 wep
+wep
+wep
+vqd
+vqd
+vqd
 dvD
-kmP
+wep
 lDu
 huP
 wep
 qoi
 vWO
-gFi
+gzX
 gzX
 gzX
 vWO
 bSS
 bUd
-bVq
-bWJ
-bYc
+wPk
+wPk
+ckr
 bZs
-aYX
+ghF
 ccr
 bSS
 csg
 cgo
 cht
-ciO
-ckn
-clO
-cmN
-coh
+coj
+iAD
+iAD
+bZn
+sVh
 cpt
 cqL
-nSv
+rrX
 fVX
 gEL
 fPT
 kYE
 wEJ
-nSv
+rrX
 cyE
 czx
 cAB
@@ -116618,18 +120026,18 @@ mKI
 sAy
 prf
 bhE
-bjp
-bkU
-jkm
+bjq
+bmV
+wep
 eAH
 qMA
 onz
-teZ
+wep
 uwx
 kPZ
 jpr
-mPv
-kPZ
+wep
+wox
 hqK
 hAL
 waL
@@ -116642,21 +120050,21 @@ ebr
 djS
 gMz
 tIB
-rSO
+cfi
 djS
-gMz
+djS
 gUC
-gMz
 djS
-csg
+djS
+ctX
 cgo
 chu
-ciP
+iAD
 cko
-clP
-cmO
-coi
-cpu
+iAD
+bZn
+fef
+hXp
 cqM
 crR
 crR
@@ -116668,7 +120076,7 @@ crR
 cyF
 czy
 cAC
-cBx
+cCA
 cCy
 cDl
 cEu
@@ -116876,12 +120284,12 @@ dJE
 eTe
 bhF
 bjq
-bkV
-pYn
+bmV
+wep
 wYd
 kMT
 moT
-teZ
+eEe
 sUI
 lvR
 msI
@@ -116896,15 +120304,15 @@ lao
 sPW
 oFB
 lXj
-djS
+bUt
 piB
 nZB
 fYa
 nKs
 pcc
 tUY
-tCA
 djS
+erX
 cfb
 cgp
 chv
@@ -116912,10 +120320,10 @@ ciQ
 ckp
 clQ
 aJW
-ccd
+deF
 cpv
 cqN
-crS
+crR
 ctf
 ctW
 cuS
@@ -116925,8 +120333,8 @@ crR
 cyG
 czz
 cAD
-cBy
-cCz
+cCA
+cCA
 cDm
 cEw
 cFr
@@ -117132,50 +120540,50 @@ pNU
 tfL
 lpS
 bhE
-bjp
-bkU
-jkm
+bjq
+bmV
+wep
 jbZ
 pyj
 xet
-teZ
+wep
 uMQ
-kPZ
+lWq
 nFG
-mPv
-kPZ
+mvj
+wpo
 emB
-hAL
-mPv
+mDX
+mHB
 kgv
-ijm
-fLM
+lao
+lao
 tpe
-oFB
+hcX
 nPo
 djS
 wBL
-oaZ
+jbd
 xlH
 gCt
-oaZ
-sfb
+lEm
+dsu
 rmu
 cdU
 cfc
 cgo
 diD
 ciR
-ckq
+gtU
 clR
 bZn
-coj
+bZn
 cpw
-cqO
-crT
+bZn
+crR
 ctg
-ctX
 cuT
+slM
 cuT
 cwW
 crR
@@ -117390,49 +120798,49 @@ uJM
 voc
 bhG
 bjr
-bkW
+bmV
+wep
 teZ
-teZ
-teZ
-teZ
-teZ
+cOY
+cPU
+wep
 wbZ
-kPZ
-msI
-pzY
-kPZ
-upO
-mDX
-lwN
+mte
+pSX
+mvj
+wpo
+bYa
+bYd
+chy
 dYw
-wlF
+lao
 kBH
 vSG
 wCs
-ijm
+lso
 jug
-fGC
-nZB
+tyj
+nKV
 aJA
-qqM
-rQv
+cks
+kmN
 fbJ
-xDL
+djS
 djS
 csg
-cgq
-cgq
-cgq
-cgq
+cgo
+cof
+crT
+ckq
 auH
-cmP
+bZn
 cmP
 cpx
 cqP
-crR
+hoL
 cth
 ctY
-cuU
+cvW
 cvW
 cwX
 cxK
@@ -117646,47 +121054,47 @@ ttQ
 hZy
 prf
 bhH
-bjp
-bkU
+bVz
+bmV
 wep
 joP
 giS
 eCf
-nzz
+wep
 vBv
-kPZ
+mvj
 eXX
-mPv
-kPZ
-jhw
-dXM
+qWu
+tlF
+upO
+mDX
 mjp
 usd
 kAx
-qSJ
-kAc
+lao
+tpe
 qfe
 dDd
 fWS
 dYt
-hpl
-ykI
+uXT
+tHs
 kmr
 tHs
 efP
-jmq
+chr
 djS
 dDr
-cgq
-chx
-chx
-chx
-cgq
-cmQ
-cok
-cpy
+cgo
+cwM
+dDu
+kxk
+oKf
+bZn
 cqQ
-cgq
+cpy
+gNs
+crR
 wmB
 ctZ
 cuV
@@ -117694,8 +121102,8 @@ cvX
 cwY
 crR
 cyJ
-cBs
-cBs
+xro
+mxR
 cBB
 fco
 cDp
@@ -117908,55 +121316,55 @@ bkX
 wep
 kDc
 wRK
-npo
-dFc
+wep
+wep
 xKw
-oBB
+sZJ
 sZJ
 pIJ
-seD
+tlF
 iuF
-kPZ
-mPv
+lYI
+mjp
 til
 unK
 pTI
 aKM
-fFa
+qfe
 iSE
-djS
+bUt
 erD
-hpl
-iaE
-naO
-tHs
+uXT
+chr
+nZE
+vCi
 hfE
 kYC
 djS
 csg
 cgq
-chx
-chx
-chx
-clS
-cmR
-col
+cgq
+cgq
+cgq
+cgq
+cqR
+cqR
 cpz
 cqR
-cgq
+crR
 ctj
 cua
 cuW
 cvY
-cvX
+fRJ
 crR
-cyK
+gCe
 cyK
 cAH
-cBC
 cyK
 cyK
 cyK
+gCe
 cyK
 cyK
 cyK
@@ -118157,51 +121565,51 @@ aYb
 dnh
 bbh
 duo
-dnh
-bfK
-bhE
-bjp
-bkU
-wep
+dnS
+bfN
+bPA
+bVB
+chD
+coi
 hrB
 gWH
 jAS
-wep
+feJ
 elo
-kPZ
+mIG
 jPl
-mPv
-kPZ
-hqK
-kPZ
-mPv
+rqx
+wGq
+qgZ
+ulI
+mHB
 mGM
 unK
-ijm
+qmX
 rQj
-opk
-kBH
+qfe
+xxO
 skb
-feU
-kQJ
+fGC
+uXT
 fCx
-fCx
-fCx
+cku
+vCi
 sfb
 jmq
 djS
 csg
 cgq
-chx
+cog
 ciT
-ckr
+chx
 clT
 cmS
 com
-cpA
+cpD
 cqS
 cgq
-dwL
+cgq
 dwL
 dwL
 dwL
@@ -118214,7 +121622,7 @@ cBD
 cCD
 uun
 rSL
-dvY
+dwL
 dyc
 gGH
 pVL
@@ -118414,63 +121822,63 @@ aYg
 aZv
 bbi
 bct
-dnh
-bfL
-bhE
-bjp
-bkU
-wep
+bOn
+bfN
+bPM
+bWJ
+bmV
+alq
 smA
-lWq
+apc
 xLe
 wep
-wep
-kqP
+iaE
+pIJ
 wpE
-emo
+pIJ
 tlF
 pRp
-ulI
+mDX
 eBu
 vWO
 xYE
 imw
-imw
+ksZ
 lvu
 oAw
 tnE
-fGC
-mtH
+bVA
+uXT
 rQv
 qqM
-itL
-fbJ
+vCi
+hfE
 wxA
 djS
 csg
 cgq
-chy
-ciU
 chx
+ciU
+kVo
 clU
 cmT
-con
+vZs
 cpB
 cqT
 crU
-dwL
+cgq
 cub
-dAp
-dAp
-dAp
+vHC
+vHC
+vHC
 gHh
 wRy
-wRy
-wRy
-cBE
-cAJ
+veB
+mtn
+mEk
+mEk
 cCE
-cCE
+oVa
 czC
 dzI
 cIl
@@ -118673,22 +122081,22 @@ dnh
 dnh
 dnh
 dnh
-bhE
-bjp
+psM
+bjC
 dCM
-wep
-rzT
-mte
-wep
+alq
+alq
+apc
+apc
 wep
 dpF
 ccU
-iaA
-iaA
-ccU
+pXC
+rzT
+tlF
 gin
 ocV
-ocV
+hzY
 rTV
 reC
 les
@@ -118696,29 +122104,29 @@ kGY
 unn
 lwz
 djS
-oKf
-uXT
-mIG
-dAX
-tHs
-efP
-jmq
+djS
+bZy
+chB
+ckv
+chB
+cmM
+chr
 djS
 csg
 cgq
 chx
 cLU
-chx
+sCS
 clU
 cmU
-coo
-cpC
+cop
+qBh
 cqU
 crV
-dwL
-cLF
-cuY
-cwa
+cgq
+lQe
+ciL
+ciL
 dzQ
 dwL
 gLC
@@ -118728,7 +122136,7 @@ cBF
 cCF
 uGW
 dqU
-dvY
+dwL
 dww
 gEk
 eZe
@@ -118927,25 +122335,25 @@ jUz
 aYh
 aHW
 aHW
-aHW
+bOe
 bdW
 bfM
 bhJ
 bjt
-bkU
+ciP
+cow
+alq
+bVC
+cQL
 wep
-vEl
-brl
 wep
-kiL
-qJk
-ccU
-jLE
-poo
-ccU
+vqd
+vqd
+wep
+vqd
 uds
-iaA
 jGA
+vqd
 vWO
 vWO
 vWO
@@ -118954,39 +122362,39 @@ vWO
 rCH
 djS
 vJE
-hpl
+ivR
 tHs
-nZE
 tHs
-efP
-rIw
+clW
+cmY
+djS
 djS
 csg
 cgq
 chA
-ciV
-cks
-cgq
+chx
+sCS
+clU
 cmV
 cop
-cpD
+hno
 cqV
 crW
-dwL
-cLF
+cgq
+lQe
 cuZ
 cuZ
 cuZ
 cuZ
 cuZ
 ioI
-krD
+cuZ
 czD
-cAL
+cyy
 cBG
 czD
-czD
-czD
+cyK
+cyK
 cFu
 dyc
 cOA
@@ -119187,22 +122595,22 @@ dnh
 dni
 dnh
 dnh
-bhE
-bjp
-bkU
+psM
+bjC
+ciP
+cqI
 alq
-boV
-brm
+alq
+alq
 wep
-wGq
 hNP
 gpH
 pUJ
 uvn
-gpH
+cdS
 tej
 tTX
-mHR
+jsx
 wgD
 vWO
 nPn
@@ -119214,23 +122622,23 @@ wQM
 oaZ
 fCx
 vCi
-fCx
-sfb
-qAS
+vCi
+cPm
 djS
-diB
+ciL
+csg
 cgq
 chx
 ciW
 ckt
-clV
+cgq
 cmW
-coq
+cop
 cpE
 cqW
-crX
-dwL
-cLF
+seI
+cgq
+lQe
 cuZ
 cwb
 lal
@@ -119243,7 +122651,7 @@ cQC
 cBH
 cCG
 cDq
-czD
+cyK
 dvY
 dvY
 dvY
@@ -119444,27 +122852,27 @@ aaa
 aaa
 aaa
 bfN
-bhK
-bju
+psM
+bjC
 bkZ
-alq
-bBj
-brn
 wep
+wep
+brn
+cQP
 wep
 ngZ
-ccU
-ccU
-jvn
-ccU
-ccU
-uds
-jvn
+mIW
+pYn
+uzY
+syK
+nCW
+syK
+uzY
 xSU
 vWO
 wni
 jig
-jig
+iSg
 hCH
 djS
 peh
@@ -119473,34 +122881,34 @@ fZR
 pwY
 iYv
 hpC
-fse
 djS
-cff
+cod
+csg
 cgq
-cgq
-cgq
-cgq
-cgq
-cgq
-cgq
+chx
+fse
+lcj
+oUA
+szl
+hDW
 cpF
+fjm
 cgq
 cgq
-dwL
-cLF
+lQe
 cuZ
 eqG
 cwZ
 cwZ
 cyM
 uYk
-krD
+cuZ
 cQv
 cAN
 cBI
 cAP
 cDr
-czD
+cyK
 aaf
 aaf
 dvY
@@ -119704,16 +123112,16 @@ tMD
 bhL
 bjv
 bla
-bmQ
-boX
-bro
+wep
 bts
+abt
+buX
 mtf
-uzY
-sNj
-oao
-poo
-ccU
+ust
+ust
+cWc
+ust
+xDD
 tRn
 hgV
 wUI
@@ -119731,33 +123139,33 @@ djS
 djS
 iqv
 djS
-djS
+coh
 cfg
-cJa
-cJa
-dAp
-dAp
-clW
-dAp
-dAp
+cgq
+cgq
+cgq
+cgq
+cgq
+cgq
+cgq
 cpG
-kVo
-dDu
+cgq
+cgq
 gra
 cuc
 cuZ
 dyp
-cwZ
-cwZ
-cyM
+xVO
+ebs
+oak
 xVP
-krD
+cuZ
 czF
-cAN
+xLQ
 cBJ
 cAP
 cDs
-czD
+cyK
 aaf
 aaa
 aaf
@@ -119958,25 +123366,25 @@ eoN
 fzU
 pcy
 tMD
-bhM
-bjw
-bkU
-alq
-apc
-apc
+psM
+bjC
+bmV
 wep
-feJ
+cwc
+cPc
+dbj
+wep
 vhg
 syK
-hKk
-qIB
+kCR
+uzY
 lPE
-ccU
+nCW
 nGs
-oao
-poo
+uzY
+ckd
 vWO
-wni
+lIk
 xbB
 uLG
 tKM
@@ -119988,33 +123396,33 @@ iSO
 pPp
 fcU
 wbK
-djS
+coq
 cfh
-dvY
-dvY
-dvY
-dvY
+cud
+cAL
+vHC
+vHC
 clX
-dvY
-dvY
-dvY
-dvY
-cuZ
+vHC
+nri
+rcz
+isX
+tIu
 sFv
-cuZ
+xqj
 cuZ
 upN
 cxN
 cxN
 qJZ
-cxO
-krD
+faz
+cuZ
 czG
 cAN
 cBK
 czD
 cDt
-czD
+cyK
 aaf
 aaa
 aaf
@@ -120218,19 +123626,19 @@ tMD
 bhN
 bjx
 blb
-alq
-boY
-bVC
 wep
-mIW
+boY
+cPd
+dht
+wep
 qfY
 hJC
 mPm
 rlw
 jsx
 rYI
-hvn
-aVt
+uzY
+cdS
 nUs
 vWO
 tdK
@@ -120244,28 +123652,28 @@ fyZ
 mwP
 iZM
 gst
-mwN
 djS
-cfi
-aqr
-chB
+alq
+alq
+cuY
+alq
 dvY
-cku
-clY
-cmY
+ciL
+cma
 dvY
+bPO
 cpH
 cqX
+ghO
+ciL
+lQe
 cuZ
-fFM
-cud
-kxk
-cxO
-cxO
+tHJ
+lzs
 cxO
 dGH
 mzh
-krD
+cuZ
 cQB
 cAO
 cBL
@@ -120472,23 +123880,23 @@ tMD
 eAd
 tMD
 tMD
-bhE
-bjp
+bRc
+bXZ
 bkY
+alq
+alq
+alq
 wep
 wep
 wep
-wep
-wep
-wep
-rbX
 vqd
-tyY
-ccU
+vqd
+wep
+vqd
 mQW
-eNY
-jBu
-nJo
+jGA
+vqd
+wep
 vWO
 vWO
 vWO
@@ -120497,38 +123905,38 @@ vWO
 bSZ
 nZH
 vWO
+ciM
+clL
 djS
 djS
 djS
-caT
-lcj
-djS
-dDs
 apc
-apb
+dDs
+uUK
+bst
 dvY
-ckv
+dvY
 clZ
-cmZ
-cor
-cpI
+dvY
+hNk
+ciL
 cqY
-cuZ
+oga
 jLY
 lzk
-lzk
+uUm
 cwd
 kfu
-cxP
-cxO
+byl
+byl
 gnZ
-krD
+cuZ
 czI
 cAP
 cAP
-czD
+cyK
 anS
-blx
+bpu
 aaa
 aaa
 aaa
@@ -120730,56 +124138,56 @@ vNm
 wiv
 smU
 dCJ
-bjp
-blc
-wep
-boZ
+bjC
+bmV
+alq
+anM
 brs
-btt
-avs
 wep
-tfX
+avs
+iYz
+uzY
 xYV
 evV
 rfm
 fdE
-nbl
-eSQ
+uzY
+uzY
 xze
-xze
+rWE
 lQo
 uyq
 eTE
-xze
+rWE
 bTa
 bUs
-bVz
+caj
 bWX
 bYo
-bVz
+cmL
 caU
 ccD
-cdV
+eoK
 cfj
-apc
+caW
 chC
 dvY
-dvY
-dvY
-dvY
-dvY
+llb
+qAS
+tfx
+itM
 cpJ
-cqZ
+cpJ
+dvY
 cuZ
 cuZ
-obb
-krD
+cuZ
 kOt
 gRS
-oUA
+cxO
 cxO
 cYI
-krD
+cuZ
 aaf
 aaf
 aaf
@@ -120986,57 +124394,57 @@ xvf
 xNY
 kyA
 smU
-eSC
-bjp
-bkU
-wep
+psM
+bjC
+bmV
+alq
 bpa
-brt
-buU
+apc
+wep
 buU
 ckY
-ccU
+naO
 gRD
-jvn
-ccU
+gRD
+gRD
 xCx
-uds
+ust
 cWc
 tuB
 uqB
 kXp
 wtU
 xZj
-xze
+vIX
 bTb
-bUt
-bVA
+uUK
+djS
 nyo
-bYp
-bZy
+clS
+djS
 tsx
-bZB
+coc
 cdW
 cfk
-apc
-chD
+alq
+alq
 dvY
 ckw
 cma
 cna
 cos
 dxh
-clY
+ehq
 crZ
 cuZ
 tVY
 krD
 oLW
 gGT
-wPk
+cxO
 dGH
 cfa
-krD
+cuZ
 aaf
 aaa
 aaf
@@ -121238,62 +124646,62 @@ pSY
 dpG
 smU
 sQY
-lep
+bMu
 qcF
 uyl
 nLA
 smU
-bhK
-bjz
-bkZ
+psM
+bjC
+bmV
+alq
+bVC
+apc
 wep
-bpb
-bru
-pXC
 oIi
-wep
+uzY
 iaA
-kKA
-ccU
-ccU
+uzY
+teR
+yhn
 dBg
 vTo
 kCR
-xze
-fXa
+iZm
+rWE
 fWz
 pGg
 dmL
-xze
+rWE
 oEM
 bUu
-xVl
-ozV
-cow
-xVl
+djS
+djS
+djS
+djS
 uUK
 alq
 alq
 cfl
 alq
-alq
+tPi
 dvY
 ckx
 fkF
-dwQ
+vfO
 cot
-cnb
+rry
 cra
 csa
 cuZ
 lMz
-krD
+cuZ
 ocT
-xkG
-wPk
+cxO
+cxO
 cxO
 kSF
-krD
+cuZ
 aaa
 aaa
 aaa
@@ -121499,40 +124907,40 @@ iAR
 kwD
 uih
 hFm
-uhi
-bhG
-bjA
-bkW
+smU
+psM
+bjC
+bmV
+alq
+alq
+apc
 wep
 wep
-wep
-wep
-wep
-wep
+jkm
 tzl
 fkx
 qIn
-ggA
-qWu
-fwb
+wep
+wep
+wep
 iIJ
-xze
-jIS
+kzk
+rWE
 ozl
 jbH
 iiE
-xze
+rWE
 ciX
 bUv
 xVl
-xVl
-mvj
-xVl
-dLK
+apc
+aqq
+umI
+uUK
 alq
 cdX
 cfm
-apc
+uAo
 chE
 dvY
 cky
@@ -121542,15 +124950,15 @@ ciL
 ciL
 cou
 adI
-dvY
-mjJ
-krD
+cuZ
+cuZ
+cuZ
 eqq
-llb
-wPk
 cxO
 cxO
-krD
+qQE
+sBf
+cuZ
 aaa
 aaa
 aaa
@@ -121727,12 +125135,12 @@ afD
 afD
 jPO
 dhw
-dnh
+boZ
 auo
 avq
 awI
-anN
-dnh
+bvz
+dnS
 axO
 dnh
 dhB
@@ -121757,38 +125165,38 @@ tVM
 hzH
 dlo
 xwg
-bhJ
-bjt
-bkU
+bSp
+bZA
+bmV
 alq
 atj
-bVC
-btv
-dbj
+apc
+xVl
+wep
+wep
+npo
+wep
+wep
+ykI
+apc
 wep
 wep
 wep
-wep
-wep
-wep
-wep
-fCR
-xze
 rWE
-xze
-bPf
-xze
-xze
+rWE
+rWE
+rWE
+rWE
 cjr
 bTe
-bVB
 bVC
+apc
 nAG
 pCV
 caW
 alq
 cdY
-bPl
+uVG
 avr
 chF
 dvY
@@ -121801,13 +125209,13 @@ cgs
 csc
 dvY
 uam
-krD
+cuZ
 dbG
 txj
-eEe
-cxO
-cxO
-krD
+tFt
+txj
+emu
+cuZ
 aaa
 aaa
 aaa
@@ -121983,11 +125391,11 @@ afD
 afD
 afD
 jPO
-dnh
-dnh
-dnh
-dnh
-dnh
+bfL
+dpk
+brl
+brm
+awI
 axM
 ayQ
 aAn
@@ -122021,27 +125429,27 @@ bmT
 bpc
 dhQ
 bGp
-buX
 bGp
+buY
 nLT
-nLT
+bIr
 dCV
-nLT
-nLT
-nLT
-bIE
+eoK
+eoK
+cbY
+ceX
+cmN
 ovd
-bTd
-bHl
-bPg
-bSc
-bSc
+ovd
+eoK
+ovd
+ovd
 eoK
 uHc
 wWN
 wWN
 pvA
-bZA
+apc
 bZE
 bZE
 bZE
@@ -122057,14 +125465,14 @@ cpK
 ciL
 csc
 dvY
-vLD
-krD
+dxk
+cuZ
 jyv
 ohj
 nnK
-cxO
-cxO
-krD
+rJS
+kYP
+cuZ
 aaa
 aaa
 aaa
@@ -122239,12 +125647,12 @@ afD
 afD
 afD
 afD
-jPO
+bfK
 arG
-asB
-aup
-dnR
-dnh
+dpk
+dpk
+brt
+awI
 aAm
 dnR
 ocS
@@ -122272,13 +125680,12 @@ nmz
 nmz
 nmz
 psM
-bjt
+bjC
 blf
 bmU
 alq
 alq
 alq
-buY
 alq
 alq
 alq
@@ -122287,9 +125694,10 @@ alq
 alq
 alq
 alq
+cgl
 qtO
-wpo
-llF
+qtO
+qtO
 qtO
 qtO
 alq
@@ -122297,8 +125705,8 @@ alq
 alq
 apb
 apb
-bWZ
-jjF
+woc
+apc
 bZE
 ccE
 cdZ
@@ -122309,19 +125717,19 @@ bZE
 ckB
 cmb
 cnc
-ciL
+fjz
 cpL
 crb
 csd
 dvY
-vLD
-krD
-krD
+lMJ
+cuZ
+cuZ
 noG
-krD
+cuZ
 noG
-krD
-krD
+cuZ
+cuZ
 aaa
 aaa
 aaa
@@ -122499,11 +125907,11 @@ afD
 jPO
 arH
 dpk
-auq
-dqp
-dnh
+dpk
+bru
+awI
 azr
-dnz
+bwJ
 ocS
 nik
 oTo
@@ -122533,7 +125941,7 @@ bjC
 blg
 bmV
 bpd
-bmV
+cPs
 btx
 buZ
 bwZ
@@ -122757,10 +126165,10 @@ jPO
 nBJ
 atd
 bai
-ate
-dDL
+btt
+btQ
 axP
-dnS
+bxr
 ocS
 pUr
 lmt
@@ -122791,7 +126199,7 @@ blh
 bmW
 bpe
 bry
-bry
+dAX
 bva
 bxa
 bHr
@@ -123011,12 +126419,12 @@ fRo
 fRo
 fRo
 fmO
-dnh
-dnR
+bmQ
+bpb
 aus
-dnS
-dnh
-aAm
+awI
+awI
+bvE
 dnS
 ocS
 owQ
@@ -123048,7 +126456,7 @@ bli
 bmX
 bpf
 brz
-bty
+dFc
 bvb
 bxb
 byQ
@@ -123267,12 +126675,12 @@ pmA
 weB
 dnz
 dnR
-dht
 dnh
-dnh
-dnh
-dnh
-dnh
+awI
+awI
+awI
+awI
+dnS
 aAm
 ayR
 ocS
@@ -123525,13 +126933,13 @@ dtE
 anN
 dnS
 doh
-dnS
+boV
 dnS
 dCi
 dnS
 dnS
 aAm
-dnS
+bxT
 ocS
 rCK
 xel
@@ -123560,7 +126968,7 @@ seS
 uJR
 rcL
 pjR
-gsy
+pTr
 oIN
 iLe
 bvd
@@ -123600,8 +127008,8 @@ crf
 aaa
 ack
 aaa
-aaa
-aaa
+gII
+rSU
 aaa
 aaa
 aaa
@@ -123786,7 +127194,7 @@ dnh
 dnh
 dnh
 dnh
-dnh
+dnS
 aAm
 ocS
 ocS
@@ -123817,7 +127225,7 @@ hKU
 kiW
 gyR
 jtI
-gsy
+cLz
 gdJ
 iLe
 bve
@@ -124072,9 +127480,9 @@ nmz
 nmz
 vsF
 kiW
-teR
+tMN
 mmy
-gsy
+pTr
 qCB
 iLe
 bCK
@@ -124328,8 +127736,8 @@ dtM
 eDX
 lLt
 fJU
-wox
-ghl
+kiW
+tMN
 nYq
 pTr
 eDP
@@ -124586,8 +127994,8 @@ iTy
 xPz
 vZw
 iMH
-tMN
-lKe
+cmO
+cqJ
 kxY
 kNr
 btz
@@ -137942,11 +141350,11 @@ xVW
 aTV
 aVm
 aWM
-aWM
+bJj
 aZS
-aWM
-aWM
-aWM
+bJj
+bJj
+bJj
 bgi
 bin
 bjR
@@ -138204,7 +141612,7 @@ bqm
 aTV
 aTV
 beu
-aWN
+bPf
 bio
 bjR
 blF
@@ -138983,8 +142391,8 @@ waU
 bpR
 byM
 btL
-bvz
-bxr
+bxq
+bxq
 bzs
 bJi
 bCD
@@ -139242,7 +142650,7 @@ brZ
 btL
 bvA
 bxs
-yhn
+bxq
 bBa
 bCD
 bEg
@@ -139497,9 +142905,9 @@ nEw
 gjy
 tQK
 btL
-btL
-btL
-btL
+feU
+kiL
+nzz
 btL
 bCD
 bEk
@@ -140011,9 +143419,9 @@ wZw
 ebf
 wqL
 xVW
-gJK
-aaa
-aaf
+xVW
+xVW
+iuC
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

Reworked several parts of service, science, and some minor areas to remove their dated looks

## Why It's Good For The Game

Old MetaStation bad

## Changelog
:cl:
add: Expanded on maintenance
del: n/a
tweak: Bar, Kitchen, Botany, Service Hall, Art Storage, Auxiliary Bathrooms, Arrivals, Arrivals Security Outpost, RD Office, Toxins, Toxins Storage, Experimentation Lab, Science Break Room were remodeled, moved, or modified in some way
fix: Several things were functioning improperly across the station
admin: Lew smelly
qol: Began layering atmospherics pipes along with optimizing disposals and the electrical web
/:cl:
