### PR TITLE
MetaStation GATO Overhaul V3

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -79582,13 +79582,20 @@
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
 "uqB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /obj/machinery/door/airlock{
 	name = "Service Hall";
 	req_access_txt = "null";
 	req_one_access_txt = "25;26;35;28"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -79865,6 +79872,10 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -428,6 +428,11 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "abV" = (
@@ -4645,9 +4650,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "apf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -4973,8 +4975,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "aqA" = (
@@ -5361,8 +5363,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "arV" = (
@@ -5823,11 +5825,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Bow Solar Access";
 	req_access_txt = "10"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "atl" = (
@@ -6143,22 +6145,14 @@
 /obj/item/clothing/mask/fakemoustache,
 /turf/open/floor/wood,
 /area/service/theater)
-"aut" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Storage Room";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "aux" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "auy" = (
@@ -6552,14 +6546,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -6568,14 +6562,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 8;
 	req_access_txt = "12"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
@@ -6584,14 +6578,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/sign/warning/radiation/rad_area{
 	dir = 1;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
@@ -6600,10 +6594,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /mob/living/simple_animal/pet/cat,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/fore)
 "avC" = (
@@ -7909,9 +7903,6 @@
 	c_tag = "Gravity Generator Room";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "azC" = (
@@ -8207,6 +8198,11 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -10345,11 +10341,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -10559,14 +10558,14 @@
 	},
 /area/command/gateway)
 "aPf" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel/dark,
+/area/engineering/gravity_generator)
 "aPl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -11175,7 +11174,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "aUb" = (
@@ -11497,12 +11496,12 @@
 /area/maintenance/starboard/fore)
 "aVf" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/engineering{
 	name = "Supermatter Engine";
 	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -11526,7 +11525,7 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVn" = (
@@ -11549,14 +11548,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVq" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVr" = (
@@ -12075,10 +12074,10 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aWM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aWN" = (
@@ -12097,7 +12096,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/circuit,
@@ -12106,7 +12105,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/circuit,
@@ -12586,10 +12585,13 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/loading_area{
+	icon_state = "steel_decals5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "aXW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12744,7 +12746,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aYB" = (
@@ -12895,7 +12897,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_whole"
+	},
 /area/hallway/primary/central)
 "aZb" = (
 /obj/structure/cable/yellow{
@@ -13180,10 +13185,10 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aZV" = (
@@ -13218,7 +13223,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aZX" = (
@@ -13549,8 +13554,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals5"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "baL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -13690,10 +13700,13 @@
 	pixel_y = -22
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "baY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -13787,6 +13800,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bbC" = (
@@ -13794,6 +13810,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/depsec/engineering,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bbD" = (
@@ -13959,11 +13978,15 @@
 /area/hallway/primary/central)
 "bcm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "steel_decals5"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "bcs" = (
 /obj/effect/turf_decal/tile/bar{
@@ -13979,9 +14002,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bcM" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bcN" = (
@@ -14267,12 +14289,14 @@
 	},
 /area/hallway/primary/central)
 "bdQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/fore)
 "bdW" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14282,7 +14306,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bem" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -14311,23 +14334,24 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
-"ben" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
+"ben" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "beo" = (
@@ -14356,14 +14380,17 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bex" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/circuit,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "beK" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -14625,8 +14652,10 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bfN" = (
@@ -14641,20 +14670,20 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port/fore)
 "bfV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "bfW" = (
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/door/airlock/security/glass{
 	name = "Engineering Security Post";
 	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -14695,32 +14724,34 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bgi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bgj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/machinery/ai_slipper{
 	uses = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bgk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bgl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -15038,16 +15069,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhI" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway - Tech Storage"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	icon_state = "steel_decals5"
+	},
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/starboard)
 "bhJ" = (
 /obj/structure/cable/yellow{
@@ -15060,19 +15092,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhL" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/loading_area{
-	dir = 1;
-	icon_state = "steel_decals"
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/loading_area{
-	icon_state = "steel_decals5"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
 	},
-/turf/open/floor/plasteel{
-	dir = 1;
-	icon_state = "floor_trim"
-	},
-/area/hallway/primary/starboard)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bhN" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -15152,7 +15179,6 @@
 /obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bio" = (
@@ -15161,9 +15187,8 @@
 	dir = 1;
 	network = list("aicore")
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -15426,7 +15451,11 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "floor_whole"
+	},
 /area/hallway/primary/starboard)
 "bjt" = (
 /obj/structure/cable/yellow{
@@ -15445,24 +15474,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bjv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	dir = 4;
-	icon_state = "floor_whole"
-	},
-/area/hallway/primary/starboard)
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
 "bjx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15552,9 +15572,15 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bjR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
 "bjS" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -15797,13 +15823,17 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "bky" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engineering/main)
 "bkA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/tank/internals/air,
@@ -15854,10 +15884,14 @@
 	pixel_y = -29
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/starboard)
 "bkY" = (
 /obj/structure/extinguisher_cabinet{
@@ -15879,15 +15913,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bla" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/loading_area{
-	dir = 1;
-	icon_state = "steel_decals5"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel{
-	icon_state = "floor_trim"
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
-/area/hallway/primary/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
 "blb" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -15945,17 +15982,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bli" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16047,8 +16079,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "blE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -16056,19 +16088,17 @@
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "blG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "blH" = (
@@ -16081,11 +16111,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "blI" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "AI Chamber";
-	req_access_txt = "16"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "AI Chamber entrance shutters";
 	name = "AI Chamber entrance shutters"
@@ -16106,6 +16131,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Chamber";
+	req_access_txt = "16"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "blT" = (
@@ -16375,8 +16406,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bmX" = (
@@ -16388,6 +16423,12 @@
 	sortType = 6
 	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16419,21 +16460,16 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bnx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bny" = (
@@ -16442,9 +16478,6 @@
 	name = "Antechamber Turret Control";
 	pixel_x = 30;
 	req_access_txt = "65"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
 	},
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -16455,11 +16488,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bnz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
 "bnA" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16469,26 +16501,20 @@
 	dir = 4;
 	network = list("minisat")
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bnB" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/landmark/start/cyborg,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bnD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -16854,9 +16880,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bpf" = (
@@ -16864,9 +16888,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16886,42 +16907,28 @@
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "bpw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
 /area/space/nearstation)
-"bpx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/transit_tube/crossing/horizontal,
-/turf/open/space,
-/area/space/nearstation)
 "bpy" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /obj/structure/transit_tube/horizontal,
 /turf/open/space,
 /area/space/nearstation)
 "bpz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16929,15 +16936,18 @@
 /obj/structure/transit_tube/junction/flipped{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/space,
 /area/space/nearstation)
 "bpA" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -16946,11 +16956,11 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -16959,19 +16969,30 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Foyer";
 	req_one_access_txt = "32;19"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bpJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -16979,11 +17000,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -16992,12 +17016,18 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Antechamber";
 	req_one_access_txt = "32;19"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -17005,8 +17035,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -17014,12 +17047,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bpP" = (
@@ -17029,7 +17060,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
@@ -17037,13 +17067,20 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bpQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bpR" = (
@@ -17052,6 +17089,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -17066,6 +17109,12 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -17464,17 +17513,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/corner,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "brM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /obj/structure/transit_tube/curved{
@@ -17487,7 +17536,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "brW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -28
@@ -17502,9 +17550,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/porta_turret/ai,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 4;
@@ -17525,9 +17570,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "brY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
 	name = "MiniSat Foyer APC";
@@ -17542,20 +17584,21 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "brZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plating,
+/area/engineering/main)
 "bsa" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -17568,10 +17611,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bsb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -17581,12 +17620,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bsd" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bse" = (
@@ -17611,9 +17653,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bsf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bsj" = (
@@ -17956,17 +17996,23 @@
 /area/security/prison)
 "btx" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "steel_decals5"
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "floor_trim"
 	},
 /area/hallway/primary/starboard)
 "bty" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
@@ -17975,7 +18021,8 @@
 	name = "Engineering Foyer Maintenance";
 	req_one_access_txt = "32;19"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "btI" = (
@@ -18004,15 +18051,16 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
 "btM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/tcommsat/computer)
-"btN" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Control Room";
-	req_one_access_txt = "19; 61"
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine";
+	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"btN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -18029,6 +18077,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Control Room";
+	req_one_access_txt = "19; 61"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "btO" = (
@@ -18081,11 +18135,14 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "btY" = (
@@ -18163,10 +18220,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bul" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "steel_decals5"
+	},
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "buK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -18182,20 +18245,28 @@
 /area/maintenance/central)
 "buL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "steel_decals5"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "buM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "steel_decals5"
+	},
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/central)
 "buU" = (
 /obj/machinery/computer/slot_machine{
@@ -18227,29 +18298,29 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "buZ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/hallway/primary/starboard)
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "bva" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bvb" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -18259,19 +18330,28 @@
 	dir = 8;
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bvd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bve" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -18317,13 +18397,19 @@
 /area/ai_monitored/turret_protected/ai)
 "bvg" = (
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bvh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plating{
@@ -18338,7 +18424,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bvw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
 	},
@@ -18346,10 +18431,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bvx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bvy" = (
@@ -18614,28 +18700,27 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "bxn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/chair/office/dark{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bxo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bxp" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bxq" = (
@@ -18862,9 +18947,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
@@ -18900,7 +18982,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bzi" = (
@@ -18930,21 +19011,27 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bzp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "bzr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/chair/office/dark,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bzs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -19034,9 +19121,6 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/central)
 "bAx" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -19048,6 +19132,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -19056,20 +19143,20 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bAz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
@@ -19121,10 +19208,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bAY" = (
@@ -19343,22 +19430,22 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "bCe" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/primary/starboard)
 "bCf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -19379,14 +19466,14 @@
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "bCF" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Server Room"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Server Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "bCG" = (
@@ -19418,10 +19505,13 @@
 /turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "bCK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bCQ" = (
@@ -19787,15 +19877,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bDM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
@@ -19806,10 +19896,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -19835,7 +19925,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "bEj" = (
@@ -20345,9 +20435,6 @@
 /turf/open/floor/plating,
 /area/medical/patients_rooms/room_a)
 "bFC" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/light/small{
 	dir = 8
@@ -20355,6 +20442,9 @@
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
@@ -20364,24 +20454,27 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bFE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "bFY" = (
@@ -20410,6 +20503,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bGj" = (
@@ -20584,7 +20678,6 @@
 	codes_txt = "patrol;next_patrol=13.3-Engineering-Central";
 	location = "13.2-Tcommstore"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
@@ -20592,9 +20685,6 @@
 "bHo" = (
 /obj/machinery/light/small{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -20631,11 +20721,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -20805,9 +20895,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
 	},
@@ -20820,9 +20907,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bIH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -20870,17 +20954,17 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bJj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bJk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "bJl" = (
@@ -21162,9 +21246,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bLZ" = (
-/obj/structure/closet/cardboard,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
 "bMo" = (
 /obj/machinery/airalarm/server{
 	dir = 4;
@@ -21181,7 +21272,7 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "bMp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -21190,7 +21281,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -21401,8 +21492,8 @@
 	dir = 1;
 	network = list("ss13","tcomms")
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/ntnet_relay,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "bOa" = (
@@ -21501,23 +21592,28 @@
 /area/maintenance/starboard/fore)
 "bPf" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "bPk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bPl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/engineering/main)
 "bPm" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -21529,11 +21625,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bPs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
-/turf/closed/wall,
-/area/maintenance/starboard)
+/turf/closed/wall/r_wall,
+/area/ai_monitored/aisat/exterior)
 "bPA" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -21663,8 +21759,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bQQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/wrench,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bQR" = (
@@ -21747,8 +21843,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bSe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bSf" = (
@@ -21825,11 +21920,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
@@ -21962,7 +22060,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bTh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bTn" = (
@@ -22365,17 +22465,12 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "bUx" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bUy" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
+/obj/structure/closet/cardboard,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bUL" = (
@@ -23112,23 +23207,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "bWZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "bXa" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -23153,11 +23243,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -23168,7 +23261,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bXd" = (
@@ -23178,29 +23274,34 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bXe" = (
-/obj/machinery/door/airlock/maintenance{
-	dir = 4;
-	name = "Atmospherics Maintenance";
-	req_access_txt = "24"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4;
+	name = "Atmospherics Maintenance";
+	req_access_txt = "24"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -23330,21 +23431,29 @@
 /area/hallway/primary/central)
 "bXN" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/side,
-/area/hallway/primary/central)
+/area/medical/medbay/central)
 "bXO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/side,
-/area/hallway/primary/central)
+/area/medical/medbay/central)
 "bXP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/medical/medbay/central)
 "bXQ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -23352,13 +23461,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXR" = (
-/obj/machinery/light/small,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXS" = (
@@ -23379,25 +23488,27 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXU" = (
-/obj/machinery/light/small,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXV" = (
 /obj/structure/sign/departments/science,
 /turf/closed/wall,
-/area/hallway/primary/central)
+/area/science/research)
 "bXW" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bXX" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/hallway/primary/central)
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "bXY" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple,
@@ -23405,7 +23516,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side,
-/area/hallway/primary/central)
+/area/science/research)
 "bXZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -23419,31 +23530,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bYa" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 6;
-	icon_state = "steel_decals6"
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 5;
-	icon_state = "steel_decals4"
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/bar)
 "bYb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
@@ -23469,11 +23555,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bYd" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "bYo" = (
 /obj/structure/disposalpipe/segment,
@@ -23499,7 +23581,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
@@ -23507,28 +23589,23 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "bYs" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "bYt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bYu" = (
 /obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bYC" = (
@@ -23764,9 +23841,6 @@
 "bYZ" = (
 /obj/item/pen,
 /obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
 /obj/item/folder/red,
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = 3;
@@ -23826,11 +23900,9 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/item/storage/box/bodybags{
-	pixel_x = 3;
-	pixel_y = 2
+/obj/structure/chair/sofachair{
+	dir = 8
 	},
-/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bZe" = (
@@ -23970,11 +24042,23 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_decals10"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 9;
+	icon_state = "steel_decals10"
+	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "bZz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance/abandoned{
+	name = "Storage Room";
+	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -24005,13 +24089,13 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "bZD" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
 	name = "Incinerator Access";
 	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
@@ -24185,60 +24269,42 @@
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "caf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cag" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cah" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
+/turf/open/floor/carpet,
+/area/service/bar)
 "cai" = (
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/syringe/epinephrine{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/structure/table/glass,
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "caj" = (
@@ -24258,6 +24324,14 @@
 "cak" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 6;
+	icon_state = "steel_decals6"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 5;
+	icon_state = "steel_decals4"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -24279,7 +24353,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/chair/sofa/corp/right,
+/obj/structure/chair/sofachair,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cao" = (
@@ -24289,7 +24364,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/chair/sofa,
+/obj/structure/rack/shelf,
+/obj/item/storage/firstaid/regular{
+	pixel_y = 10
+	},
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cap" = (
@@ -24299,7 +24378,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/chair/sofa/corp/left,
+/obj/structure/table/glass,
+/obj/item/storage/box/bodybags{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/storage/box/bodybags{
+	pixel_x = 4;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "caq" = (
@@ -24311,6 +24398,12 @@
 "car" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -24365,44 +24458,48 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "caw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cay" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"cay" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "caA" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass,
-/obj/item/electronics/airlock,
-/obj/item/assembly/timer{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "caB" = (
 /obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+	dir = 1;
+	pixel_y = 12
 	},
 /obj/machinery/camera{
 	c_tag = "Research Division - Lobby";
 	network = list("ss13","rd");
 	pixel_y = 12
 	},
-/obj/structure/table,
-/obj/item/stock_parts/cell/potato,
+/obj/structure/rack/shelf,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 7
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = -4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "caC" = (
@@ -24543,10 +24640,10 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
 "caX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "caY" = (
@@ -24884,25 +24981,26 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "cbS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "cbT" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+	dir = 1
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cbU" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -24910,21 +25008,25 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cbV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cbW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/mob/living/simple_animal/bot/medbot{
+	auto_patrol = 1;
+	desc = "A little medical robot, officially part of the GATO medical inspectorate. He looks somewhat underwhelmed.";
+	name = "Inspector Johnson"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -24932,12 +25034,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/item/storage/box/bodybags{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/stack/medical/gauze,
 /obj/structure/table/glass,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 9
+	},
+/obj/item/book/manual/wiki/surgery{
+	pixel_x = 6;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cbY" = (
@@ -25010,6 +25114,14 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 6;
+	icon_state = "steel_decals6"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 5;
+	icon_state = "steel_decals4"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -25163,16 +25275,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "ccU" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
 /obj/structure/chair/comfy/black,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "cdb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -25399,14 +25503,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "cdy" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/shower{
-	dir = 4;
-	name = "emergency shower"
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -25423,44 +25520,58 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_decals3"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals3"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cdB" = (
-/mob/living/simple_animal/bot/medbot{
-	auto_patrol = 1;
-	desc = "A little medical robot, officially part of the GATO medical inspectorate. He looks somewhat underwhelmed.";
-	name = "Inspector Johnson"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cdC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cdD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cdE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cdF" = (
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
@@ -25470,19 +25581,22 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
 /area/medical/medbay/central)
 "cdG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -25490,15 +25604,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -25543,7 +25657,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cdL" = (
@@ -25558,6 +25671,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cdM" = (
@@ -25975,9 +26090,6 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "ceD" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -25991,10 +26103,12 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ceF" = (
-/obj/structure/bed/roller,
 /obj/item/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
@@ -26013,15 +26127,33 @@
 /area/medical/medbay/central)
 "ceG" = (
 /obj/machinery/light,
-/obj/structure/bed/roller,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = 6;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ceH" = (
-/obj/structure/bed/roller,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_y = 12
+	},
+/obj/item/stack/medical/gauze,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ceI" = (
@@ -26044,25 +26176,37 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ceK" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ceL" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_y = 6
+	},
+/obj/item/gps{
+	gpstag = "RD0";
+	pixel_x = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/machinery/newscaster{
+	pixel_x = -1;
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "ceM" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
@@ -26083,13 +26227,19 @@
 /area/science/research)
 "ceO" = (
 /obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_x = -1;
-	pixel_y = -29
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/glass,
+/obj/item/electronics/airlock,
+/obj/item/assembly/timer{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/machinery/firealarm{
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -26210,6 +26360,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/closet/wardrobe/science_white,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "cfb" = (
@@ -26606,9 +26757,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cfT" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -26637,6 +26785,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -27049,15 +27200,7 @@
 /turf/open/floor/plating,
 /area/medical/medbay/central)
 "cgZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -27070,6 +27213,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cha" = (
@@ -27091,6 +27239,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "chb" = (
@@ -27181,17 +27332,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "chg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"chh" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway - Tech Storage"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"chh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "chi" = (
 /obj/structure/table,
 /obj/item/crowbar,
@@ -27353,26 +27508,6 @@
 "chx" = (
 /turf/open/floor/engine,
 /area/science/explab)
-"chy" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 10;
-	icon_state = "steel_decals3"
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1;
-	icon_state = "steel_decals3"
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/bar)
 "chA" = (
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab - Test Chamber";
@@ -27606,14 +27741,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cit" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -27624,9 +27753,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ciu" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -27635,6 +27761,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -28082,14 +28211,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cjQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -28102,6 +28231,9 @@
 	name = "emergency shower"
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cjS" = (
@@ -28333,7 +28465,7 @@
 "ckk" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
-/area/hallway/primary/central)
+/area/medical/medbay/central)
 "ckl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -28986,14 +29118,13 @@
 /turf/open/floor/plating,
 /area/science/explab)
 "clV" = (
-/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/structure/table/glass,
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "clW" = (
@@ -29314,10 +29445,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard)
-"cmO" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
 "cmP" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/loading_area{
@@ -29457,10 +29584,10 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "cmZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cna" = (
@@ -29707,7 +29834,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -29830,6 +29956,17 @@
 	dir = 1;
 	pixel_y = 12
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 6;
+	icon_state = "steel_decals6"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 5;
+	icon_state = "steel_decals4"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "coc" = (
@@ -29850,6 +29987,7 @@
 /area/maintenance/starboard/aft)
 "coe" = (
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cof" = (
@@ -29953,7 +30091,7 @@
 "cor" = (
 /obj/structure/girder,
 /obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cos" = (
@@ -30242,13 +30380,25 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cpa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_whole"
+	},
+/area/hallway/primary/starboard)
 "cpb" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -30421,6 +30571,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 1
 	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cpn" = (
@@ -30439,17 +30591,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cpq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -31144,6 +31294,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_decals3"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals3"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqG" = (
@@ -31159,6 +31317,7 @@
 /obj/structure/sign/warning/biohazard{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cqI" = (
@@ -31180,6 +31339,14 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
@@ -31253,7 +31420,7 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/structure/closet/radiation,
+/obj/structure/closet/bombcloset,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "cqR" = (
@@ -31572,7 +31739,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
@@ -31609,12 +31775,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "crM" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "crR" = (
@@ -32045,14 +32214,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /turf/open/floor/plasteel,
@@ -32068,8 +32237,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -32103,17 +32272,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
@@ -32244,6 +32413,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ctf" = (
@@ -32266,6 +32439,8 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/effect/landmark/start/scientist,
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cth" = (
@@ -32394,19 +32569,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"ctF" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"ctG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "ctH" = (
 /obj/structure/sign/directions/evac,
 /turf/closed/wall,
@@ -32448,9 +32610,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ctP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -32482,7 +32641,6 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "ctY" = (
-/obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -32808,7 +32966,6 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "cuA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -32825,6 +32982,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cuC" = (
@@ -32884,9 +33042,10 @@
 	},
 /area/hallway/primary/central)
 "cuI" = (
-/obj/machinery/airalarm{
+/obj/machinery/camera{
+	c_tag = "Research Division Hallway - Mech Bay";
 	dir = 4;
-	pixel_x = -23
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -32901,6 +33060,13 @@
 /area/science/research)
 "cuK" = (
 /obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cuS" = (
@@ -33218,7 +33384,6 @@
 /turf/open/floor/plating,
 /area/medical/genetics)
 "cvG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
@@ -33241,6 +33406,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cvJ" = (
@@ -33253,11 +33419,7 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cvL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "researchrangeshutters"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/science/misc_lab/range)
 "cvM" = (
 /obj/effect/turf_decal/tile/purple{
@@ -33637,7 +33799,6 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "cwF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -33659,6 +33820,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cwH" = (
@@ -33724,25 +33886,6 @@
 	dir = 5
 	},
 /area/science/research)
-"cwN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cwO" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "cwV" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
@@ -33759,7 +33902,6 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cwX" = (
-/obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -34026,9 +34168,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -34038,23 +34177,29 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cxB" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.1-Escape-1";
 	location = "8.1-Aft-to-Escape"
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cxC" = (
@@ -34063,6 +34208,12 @@
 	name = "Mech Bay"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cxD" = (
@@ -34070,19 +34221,22 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cxE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "cxF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "cxG" = (
@@ -34135,14 +34289,17 @@
 	name = "Toxins Storage";
 	req_access_txt = "8"
 	},
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel,
 /area/science/storage)
 "cxL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
@@ -34150,7 +34307,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
 	},
 /turf/open/floor/catwalk_floor,
@@ -34419,25 +34582,24 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cyo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals5"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel{
+	icon_state = "floor_trim"
+	},
+/area/hallway/primary/starboard)
 "cyp" = (
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
 	name = "Mech Bay"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cyq" = (
@@ -34445,10 +34607,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cyr" = (
@@ -34476,11 +34638,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/camera{
-	c_tag = "Research Division Hallway - Mech Bay";
-	dir = 4;
-	network = list("ss13","rd")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -34488,7 +34647,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cyx" = (
@@ -34500,14 +34662,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cyy" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall,
-/area/science/mixing)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/engineering/break_room)
 "cyA" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/disposal/bin{
 	pixel_x = -2;
 	pixel_y = -2
@@ -34520,7 +34681,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyC" = (
@@ -34529,60 +34689,100 @@
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cyE" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cyF" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 24
-	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cyG" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"cyE" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"cyF" = (
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 24
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/assembly/prox_sensor{
+	pixel_x = 12;
+	pixel_y = 8
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 12;
+	pixel_y = 6
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/assembly/timer{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"cyG" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 12
+	},
+/obj/structure/table/reinforced,
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/transfer_valve{
+	pixel_x = 5
+	},
+/obj/item/transfer_valve,
+/obj/item/transfer_valve,
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
+/obj/item/transfer_valve{
+	pixel_x = -5
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyH" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins - Lab";
 	network = list("ss13","rd");
 	pixel_y = 12
 	},
+/obj/structure/table/reinforced,
+/obj/item/pipe_dispenser{
+	pixel_y = 8
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = 4
+	},
+/obj/item/analyzer,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyI" = (
@@ -34602,13 +34802,37 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "cyJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/multitool{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "cyK" = (
 /turf/closed/wall/r_wall,
@@ -34793,17 +35017,18 @@
 /area/medical/genetics)
 "czc" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "czd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
@@ -34812,14 +35037,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	id_tag = "AuxGenetics";
 	name = "Genetics Access";
 	req_access_txt = "9"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
@@ -34827,20 +35052,26 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "czg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engineering/break_room)
 "czh" = (
 /obj/machinery/button/door{
 	id = "Skynet_launch";
@@ -34850,7 +35081,9 @@
 	req_one_access_txt = "29"
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "czi" = (
@@ -34871,10 +35104,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "czj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
 "czk" = (
@@ -34915,6 +35149,7 @@
 	icon_state = "right";
 	name = "door"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/engine{
 	dir = 9;
 	icon_state = "floor"
@@ -34936,53 +35171,18 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "czo" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"czp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "czq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 10
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"czr" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	dir = 4;
-	id = "toxins_blastdoor";
-	name = "biohazard containment door"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel,
+/area/engineering/break_room)
 "czs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -34992,10 +35192,6 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port)
 "czt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/button/door{
 	id = "toxins_blastdoor";
 	name = "Toxins Shutter Control";
@@ -35007,34 +35203,45 @@
 	pixel_y = -10
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "czv" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "czw" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/machinery/meter,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/loading_area{
+	dir = 6;
+	icon_state = "steel_decals6"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 5;
+	icon_state = "steel_decals4"
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "czx" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "czy" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "czz" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/start/scientist,
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "czA" = (
 /obj/structure/cable/yellow{
@@ -35043,30 +35250,28 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"czB" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"czB" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/science/mixing)
 "czC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12;47"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "czD" = (
@@ -35103,6 +35308,10 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -35119,9 +35328,6 @@
 	desc = "A secure crate containing various materials for building a customised test-site.";
 	name = "Test Site Materials Crate";
 	req_access_txt = "8"
-	},
-/obj/machinery/light/small{
-	dir = 1
 	},
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -35422,9 +35628,6 @@
 	c_tag = "Aft Primary Hallway - Middle";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -35434,28 +35637,28 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cAj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cAk" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	name = "Mech Bay";
 	req_access_txt = "29"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
@@ -35466,17 +35669,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cAm" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35491,9 +35699,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cAp" = (
@@ -35506,7 +35715,6 @@
 /obj/item/target/clown,
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light_switch{
 	pixel_x = -25
 	},
@@ -35516,36 +35724,34 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cAq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cAr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cAs" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	dir = 4;
-	name = "Research Testing Range";
-	req_one_access_txt = "7;47;29"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -35559,12 +35765,20 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	dir = 4;
+	name = "Research Testing Range";
+	req_one_access_txt = "7;47;29"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cAt" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -35573,6 +35787,12 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -35586,45 +35806,58 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cAv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cAw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
 	dir = 4;
 	id = "toxins_blastdoor";
 	name = "biohazard containment door"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -35640,17 +35873,27 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /obj/machinery/door/airlock/research{
 	dir = 8;
@@ -35663,7 +35906,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
@@ -35673,27 +35915,27 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "cAz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "cAA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -35703,35 +35945,30 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cAB" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "cAC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "cAD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
@@ -35743,21 +35980,31 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/science/mixing)
 "cAE" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/start/scientist,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/science/mixing)
 "cAF" = (
 /obj/structure/disposalpipe/segment{
@@ -35767,34 +36014,22 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/open/floor/engine,
 /area/science/mixing)
 "cAG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Toxins - Mixing Area";
-	dir = 8;
-	network = list("ss13","rd")
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/science/mixing)
 "cAH" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "toxins_blastdoor";
-	name = "biohazard containment shutters"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -35804,37 +36039,46 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"cAI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "toxins_blastdoor";
+	name = "biohazard containment shutters"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	name = "Toxins Launch Room Access";
 	req_access_txt = "8"
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/mixing)
-"cAI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -35842,9 +36086,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/chair/comfy{
-	dir = 1
-	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cAL" = (
@@ -36000,7 +36242,6 @@
 /area/hallway/primary/aft)
 "cBe" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -36022,6 +36263,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cBi" = (
@@ -36039,9 +36282,6 @@
 	name = "Station Intercom (General)";
 	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -36053,9 +36293,6 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "researchrangeshutters";
 	name = "Blast Door Control";
@@ -36063,6 +36300,9 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cBl" = (
@@ -36073,9 +36313,6 @@
 	pixel_y = -28
 	},
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -36083,50 +36320,50 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cBm" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
+	dir = 4;
 	id = "researchrangeshutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/misc_lab/range)
 "cBn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cBo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel,
+/area/engineering/break_room)
 "cBq" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 29
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
 	dir = 4;
 	id = "toxins_blastdoor";
 	name = "biohazard containment door"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -36147,75 +36384,21 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port)
 "cBu" = (
-/obj/item/assembly/prox_sensor{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = 8;
-	pixel_y = 9
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = 9;
-	pixel_y = -2
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_y = 2
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBv" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/scientist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_decals3"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals3"
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
-"cBw" = (
-/obj/structure/table/reinforced,
-/obj/item/wrench,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/item/analyzer,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cBz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cBA" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cBB" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/science/mixing";
-	dir = 4;
-	name = "Toxins Lab APC";
-	pixel_x = 26
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cBC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -36228,14 +36411,16 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port)
 "cBD" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
+/obj/structure/transit_tube/horizontal,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
+/turf/open/space,
+/area/space/nearstation)
 "cBE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -36248,6 +36433,9 @@
 "cBF" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
+	},
+/obj/structure/chair/comfy{
+	dir = 1
 	},
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
@@ -36281,6 +36469,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24;
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -36490,7 +36682,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "cCm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 29
@@ -36519,13 +36710,14 @@
 	req_access_txt = "29"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cCq" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
 "cCr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -36548,53 +36740,20 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "cCu" = (
-/obj/structure/closet/wardrobe/science_white,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCv" = (
-/obj/item/assembly/signaler{
-	pixel_y = 8
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/assembly/signaler{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCw" = (
-/obj/item/transfer_valve{
-	pixel_x = -5
-	},
-/obj/item/transfer_valve{
-	pixel_x = -5
-	},
-/obj/item/transfer_valve,
-/obj/item/transfer_valve,
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
-/obj/item/transfer_valve{
-	pixel_x = 5
-	},
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
@@ -36602,62 +36761,50 @@
 	pixel_y = -30;
 	receive_ore_updates = 1
 	},
-/obj/structure/table/reinforced,
 /obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCx" = (
-/obj/item/assembly/timer{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/obj/item/assembly/timer{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/assembly/timer{
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/item/assembly/timer,
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCy" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/tank_dispenser,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCA" = (
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cCB" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cCD" = (
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"cCD" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel{
+	icon_state = "floor_whole"
+	},
+/area/hallway/primary/central)
 "cCE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCF" = (
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCG" = (
@@ -36802,16 +36949,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cCW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cCX" = (
 /obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cCY" = (
@@ -36857,6 +36999,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cDd" = (
@@ -36915,11 +37059,19 @@
 /turf/closed/wall,
 /area/science/robotics/lab)
 "cDj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "steel_decals5"
+	},
+/turf/open/floor/plasteel{
+	dir = 8;
+	icon_state = "floor_trim"
+	},
+/area/hallway/primary/central)
 "cDk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "cDl" = (
@@ -36927,41 +37079,16 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "cDm" = (
-/obj/machinery/shower{
-	dir = 4;
-	name = "emergency shower"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cDn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cDo" = (
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cDp" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/multitool{
-	pixel_x = 3
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
+/area/science/mixing)
+"cDp" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/science/mixing)
 "cDq" = (
 /obj/machinery/mass_driver{
@@ -37325,14 +37452,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cEc" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -37346,16 +37471,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "cEf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/closed/wall,
 /area/hallway/primary/aft)
 "cEg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -37366,15 +37484,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cEh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "cEi" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -37421,9 +37539,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cEl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -37433,12 +37548,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cEm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -37451,9 +37565,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cEn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -37487,11 +37598,12 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cEp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white/side{
-	dir = 9
+/obj/effect/turf_decal/box/corners{
+	dir = 8
 	},
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cEq" = (
 /obj/structure/lattice,
@@ -37543,33 +37655,27 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/engine,
 /area/science/mixing)
 "cEx" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
 	name = "manual outlet valve"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/engine,
 /area/science/mixing)
 "cEy" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/obj/item/pipe_dispenser,
+/turf/open/floor/engine,
 /area/science/mixing)
 "cEz" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/item/storage/firstaid/toxin,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
 /area/science/mixing)
 "cEA" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -37783,10 +37889,16 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cEW" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -37794,6 +37906,9 @@
 "cEX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -37803,14 +37918,20 @@
 	name = "Morgue";
 	req_access_txt = "6"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cEZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "cFa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -37818,7 +37939,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37827,13 +37951,15 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/departments/science{
 	name = "\improper ROBOTICS!";
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -37849,7 +37975,8 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cFe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cFf" = (
@@ -37865,7 +37992,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cFi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -37897,31 +38023,16 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cFk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Research Division Hallway - Robotics";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"cFl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
 "cFm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/science/research)
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "cFn" = (
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
@@ -37939,13 +38050,9 @@
 /turf/open/floor/engine,
 /area/science/mixing)
 "cFr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"cFs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cFu" = (
@@ -38285,7 +38392,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "cFZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -38313,17 +38419,26 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cGc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cGd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/engineering/atmos)
 "cGe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -38347,29 +38462,32 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cGg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Research Division Hallway - Robotics";
+	dir = 4;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cGh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cGi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/science/research)
 "cGj" = (
 /obj/machinery/sparker/toxmix{
@@ -38403,32 +38521,24 @@
 	pixel_x = -25;
 	pixel_y = -5
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/engine,
 /area/science/mixing)
 "cGm" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
 	name = "manual inlet valve"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/engine,
 /area/science/mixing)
 "cGn" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/science/mixing)
 "cGo" = (
 /obj/structure/closet/crate,
@@ -38881,12 +38991,14 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cGU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -38903,27 +39015,35 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cGW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
-"cGX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_x = 24;
+	pixel_y = -24;
+	req_access_txt = "24"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
+"cGX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cGY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -38959,19 +39079,13 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cGZ" = (
-/obj/effect/spawner/structure/window,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "cHa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -38984,31 +39098,34 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cHc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cHd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
 	name = "SERVER ROOM"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/science/server)
 "cHe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -39017,34 +39134,15 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/server)
-"cHg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing)
 "cHh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Toxins Lab Maintenance";
-	req_access_txt = "8"
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "toxins_blastdoor";
-	name = "biohazard containment shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/engine,
+/area/science/mixing)
 "cHi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/engine,
 /area/science/mixing)
 "cHl" = (
 /obj/structure/table/glass,
@@ -39414,7 +39512,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
@@ -39427,11 +39528,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -39441,6 +39542,10 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -39460,61 +39565,76 @@
 /area/science/robotics/lab)
 "cHR" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cHS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cHT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cHU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cHV" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	name = "Robotics Lab";
 	req_access_txt = "29"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
+/area/science/robotics/lab)
+"cHW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
-"cHW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39526,18 +39646,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cHY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -39547,13 +39666,13 @@
 /area/science/research)
 "cHZ" = (
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /obj/machinery/door/airlock/command{
 	dir = 8;
 	name = "Research Division Server Room";
 	req_access_txt = "30"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -39596,36 +39715,31 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "cIh" = (
-/obj/structure/closet,
-/obj/item/storage/box/lights/mixed,
-/obj/item/flashlight,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cIi" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard/aft)
-"cIj" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/structure/sign/warning/biohazard{
-	pixel_y = 32
+/turf/closed/wall/r_wall,
+/area/science/mixing)
+"cIi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
 	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/starboard/aft)
+/turf/closed/wall/r_wall,
+/area/science/mixing)
+"cIj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "cIk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/brown{
@@ -39641,12 +39755,10 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cIm" = (
@@ -39681,7 +39793,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 10
 	},
 /turf/open/floor/catwalk_floor,
@@ -39885,7 +39997,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
 "cIE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -39898,10 +40009,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/aft)
 "cIG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Aft";
 	dir = 8
@@ -40010,19 +40122,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cIR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cIS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 29
@@ -40103,7 +40212,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cJb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/storage/box,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cJc" = (
@@ -40113,7 +40223,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "cJd" = (
@@ -40437,13 +40547,12 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "cJE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Departure Lounge"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Departure Lounge"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -40455,15 +40564,16 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cJG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cJH" = (
@@ -40556,16 +40666,25 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cJQ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_decals3"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals3"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -40616,36 +40735,37 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "cJY" = (
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/trash_pile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "cJZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/maintenance/starboard/aft)
 "cKa" = (
-/obj/structure/closet,
-/obj/item/clothing/glasses/science,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	dir = 8;
+	name = "Bar"
+	},
+/turf/open/floor/carpet,
+/area/service/bar)
 "cKb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cKc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "cKe" = (
@@ -40898,42 +41018,40 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cKC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cKD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
+	dir = 8;
+	name = "Air to External Air Ports"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
+/area/engineering/atmos)
 "cKE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cKF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
@@ -40955,16 +41073,20 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cKH" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Robotics Maintenance";
-	req_access_txt = "29"
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/engineering/atmos)
 "cKI" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/science/research)
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "cKJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40979,44 +41101,51 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "cKL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance/abandoned{
 	dir = 8;
 	name = "Storage Room";
 	req_one_access_txt = "12;47"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cKM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cKN" = (
 /obj/item/storage/box/lights/mixed,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cKO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 10
 	},
 /turf/open/floor/plating{
@@ -41027,14 +41156,18 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "cKQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Quarter Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cKR" = (
@@ -41301,7 +41434,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41310,40 +41443,52 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cLu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cLv" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 8;
 	req_one_access_txt = "12;47"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
@@ -41351,10 +41496,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
@@ -41363,42 +41511,49 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
 "cLy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
-"cLz" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
 "cLA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
 	req_one_access_txt = "12;47"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
@@ -41457,6 +41612,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cLE" = (
@@ -41470,8 +41626,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
@@ -41483,18 +41642,21 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cLJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/closet,
 /obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cLK" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -41505,10 +41667,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cLN" = (
@@ -41639,7 +41801,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cMi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -41647,6 +41808,7 @@
 	codes_txt = "patrol;next_patrol=9.2-Escape-2";
 	location = "9.1-Escape-1"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cMj" = (
@@ -41672,6 +41834,9 @@
 	pixel_y = -4
 	},
 /obj/item/stack/sheet/metal/fifty,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cMm" = (
@@ -41714,7 +41879,7 @@
 /area/maintenance/solars/starboard/aft)
 "cMr" = (
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plating{
@@ -42318,7 +42483,7 @@
 	name = "old sink";
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plating{
@@ -42327,23 +42492,23 @@
 /area/maintenance/starboard/aft)
 "cNX" = (
 /obj/item/seeds/watermelon,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cNY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cNZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/chair,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 9
 	},
-/obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOa" = (
@@ -42506,12 +42671,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/engineering/atmos)
 "cOD" = (
 /obj/item/seeds/berry,
 /turf/open/floor/plating,
@@ -42707,9 +42873,6 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "cPs" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
 	},
@@ -42742,7 +42905,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
@@ -42753,6 +42916,9 @@
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 3;
 	name = "3maintenance loot spawner"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -42848,16 +43014,10 @@
 	},
 /area/maintenance/aft)
 "cPX" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab";
-	req_access_txt = "47"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -42868,6 +43028,12 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Lab";
+	req_access_txt = "47"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -42921,14 +43087,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cQr" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Xenobiology Lab Access";
@@ -42940,29 +43100,39 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"cQs" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"cQs" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/area/science/research)
 "cQt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -42973,25 +43143,26 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/area/science/research)
 "cQv" = (
 /obj/machinery/camera{
 	c_tag = "Toxins - Launch Area";
-	network = list("ss13","rd")
+	network = list("ss13","rd");
+	pixel_y = 12
 	},
-/obj/machinery/suit_storage_unit/rd,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -43012,12 +43183,6 @@
 	},
 /area/science/mixing)
 "cQC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_y = 25
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -43096,25 +43261,25 @@
 /turf/open/floor/carpet/black,
 /area/service/bar)
 "cQR" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno_blastdoor";
-	name = "biohazard containment door"
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "cQS" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno_blastdoor";
-	name = "biohazard containment door"
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "cQY" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -43124,6 +43289,32 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cQZ" = (
+/obj/effect/landmark/blobstart,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"cRa" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall,
+/area/science/xenobiology)
+"cRb" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno_blastdoor";
+	name = "biohazard containment door"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
+"cRc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -43132,40 +43323,8 @@
 	name = "biohazard containment door"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"cRa" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall,
-/area/science/xenobiology)
-"cRb" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall,
-/area/science/xenobiology)
-"cRc" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab";
-	req_access_txt = "47"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "cRe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43177,20 +43336,29 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Lab";
+	req_access_txt = "47"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cRg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "cRh" = (
 /obj/structure/sink{
 	dir = 8;
@@ -43252,7 +43420,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1449;
@@ -43260,16 +43427,7 @@
 	name = "Xenobiology Lab External Airlock";
 	req_access_txt = "55"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cRw" = (
@@ -44222,9 +44380,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "cVp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -44445,13 +44600,11 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "cYI" = (
-/obj/machinery/camera{
-	c_tag = "Research Division Circuitry Lab";
-	dir = 1;
-	network = list("ss13","rd")
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -44594,14 +44747,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
-"cZV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "dal" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -46058,15 +46203,15 @@
 /turf/open/space,
 /area/space/nearstation)
 "dgS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/transit_tube/horizontal,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/transit_tube/horizontal,
 /turf/open/space,
 /area/space/nearstation)
 "dha" = (
@@ -46546,17 +46691,11 @@
 /turf/open/floor/carpet,
 /area/medical/medbay/aft)
 "diP" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 6
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "diQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -46592,11 +46731,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -46640,19 +46782,19 @@
 /area/maintenance/starboard/aft)
 "djg" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"djh" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
+"djh" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "djs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -46796,22 +46938,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "dlt" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/atmospherics/components/binary/pump/layer3{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/ash/large,
-/obj/item/kitchen/fork{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/science/research)
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dlA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -46835,8 +46966,8 @@
 /turf/open/space,
 /area/solars/starboard/aft)
 "dlF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
@@ -47110,15 +47241,17 @@
 /turf/open/floor/carpet/black,
 /area/service/theater)
 "dpm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -47163,15 +47296,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "dpG" = (
 /obj/structure/cable/yellow{
@@ -47252,7 +47377,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/mealdor,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "drM" = (
@@ -47348,9 +47473,12 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "dsL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/engineering/main)
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dti" = (
 /obj/item/beacon,
 /obj/structure/cable/yellow{
@@ -47376,13 +47504,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = 26;
-	pixel_y = -26;
-	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -47504,7 +47625,8 @@
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "dux" = (
@@ -47671,10 +47793,16 @@
 /area/maintenance/port/aft)
 "dwv" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dww" = (
 /obj/structure/closet/firecloset,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dwL" = (
@@ -47685,7 +47813,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dwW" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -47735,11 +47863,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "dxv" = (
@@ -47765,8 +47894,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -47828,13 +47960,14 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "dzI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dzK" = (
@@ -47877,17 +48010,18 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "dAd" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/maintenance/starboard/aft";
-	name = "Starboard Quarter Maintenance APC";
-	pixel_y = -24
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAh" = (
-/obj/item/storage/box,
+/obj/structure/closet,
+/obj/item/storage/box/lights/mixed,
+/obj/item/flashlight,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAn" = (
@@ -47905,24 +48039,35 @@
 /area/maintenance/starboard/aft)
 "dAp" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "dAw" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 8;
 	req_one_access_txt = "12;47"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -47930,10 +48075,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -47948,14 +48096,18 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel{
+	icon_state = "floor_whole"
+	},
 /area/hallway/primary/starboard)
 "dAZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "dBe" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -48244,11 +48396,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "dCJ" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	icon_state = "steel_decals5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 1;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/starboard)
 "dCM" = (
 /obj/structure/extinguisher_cabinet{
@@ -48340,6 +48495,9 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dDp" = (
@@ -48407,9 +48565,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dDw" = (
@@ -48422,10 +48577,13 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dDz" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "dDA" = (
@@ -48433,16 +48591,16 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "dDB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48478,10 +48636,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "dDG" = (
@@ -48538,10 +48699,15 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "dFc" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "steel_decals5"
 	},
-/turf/open/floor/plasteel/dark/corner,
+/turf/open/floor/plasteel{
+	dir = 4;
+	icon_state = "floor_trim"
+	},
 /area/hallway/primary/starboard)
 "dFh" = (
 /obj/machinery/suit_storage_unit/cmo,
@@ -48554,9 +48720,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
 "dFX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
 	},
@@ -48570,8 +48733,8 @@
 /area/engineering/break_room)
 "dGD" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
@@ -48597,20 +48760,11 @@
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "dHR" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
-"dHX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engineering/atmos)
 "dIl" = (
 /obj/item/stack/sheet/rglass{
@@ -48653,9 +48807,6 @@
 /area/ai_monitored/command/storage/eva)
 "dIo" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior Access";
@@ -48730,8 +48881,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -48751,17 +48905,19 @@
 	pixel_y = -3
 	},
 /obj/item/clothing/gloves/color/latex,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "dLm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Inner Pipe Access";
+	req_access_txt = "24"
 	},
-/turf/closed/wall/r_wall,
-/area/engineering/gravity_generator)
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
 "dLs" = (
 /obj/item/stack/cable_coil,
 /obj/structure/lattice/catwalk,
@@ -48908,16 +49064,19 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	icon_state = "floor_whole"
+	},
 /area/hallway/primary/central)
 "dRb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -49078,6 +49237,12 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "dVE" = (
@@ -49164,8 +49329,9 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "dXa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -49234,12 +49400,12 @@
 	},
 /area/service/kitchen)
 "dYF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -49274,8 +49440,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "eai" = (
@@ -49343,12 +49510,13 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "ebf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "ebr" = (
@@ -49609,11 +49777,6 @@
 /area/service/chapel/main)
 "ejj" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	dir = 8;
-	name = "Engineering Foyer";
-	req_one_access_txt = "32;19"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -49625,6 +49788,17 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	dir = 8;
+	name = "Engineering Foyer";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
@@ -49710,12 +49884,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "elo" = (
@@ -49731,18 +49904,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "elv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -49762,12 +49927,10 @@
 	},
 /area/command/heads_quarters/rd)
 "elC" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "elE" = (
@@ -49804,9 +49967,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "emC" = (
 /obj/structure/window/reinforced{
@@ -49862,13 +50023,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49880,18 +50041,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_y = 6
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
+	dir = 8
 	},
-/obj/item/gps{
-	gpstag = "RD0";
-	pixel_x = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -4;
-	pixel_y = -3
-	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "erD" = (
@@ -49969,9 +50122,9 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "esR" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
 	dir = 8;
-	name = "Mix to Filter"
+	name = "Mix to Waste"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -50099,13 +50252,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "exO" = (
@@ -50171,7 +50325,6 @@
 /area/engineering/main)
 "ezu" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "ezN" = (
@@ -50268,32 +50421,23 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "eBe" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "eBq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "eBu" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "eBD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
@@ -50357,8 +50501,8 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
@@ -50390,31 +50534,32 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "eCS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "eCZ" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "eDc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "eDr" = (
@@ -50560,9 +50705,6 @@
 "eHP" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine";
 	req_access_txt = "10"
@@ -50634,11 +50776,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "eKD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/power/terminal,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "eKY" = (
@@ -50724,9 +50864,6 @@
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
 "eOd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -50826,8 +50963,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "eQs" = (
@@ -50874,8 +51012,8 @@
 /area/service/chapel/main)
 "eRy" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -51207,13 +51345,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "eZS" = (
 /obj/machinery/door/poddoor/preopen{
+	dir = 4;
 	id = "transittube";
 	name = "Transit Tube Blast Door"
 	},
@@ -51221,6 +51357,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "faz" = (
@@ -51232,6 +51374,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -51345,30 +51490,10 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "fco" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/science/mixing)
 "fcO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -51421,7 +51546,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
@@ -51516,9 +51640,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 26
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	name = "Auxiliary MiniSat Distribution Port"
-	},
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -51530,6 +51651,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "ffN" = (
@@ -51549,9 +51671,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "fgj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51575,7 +51695,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -51623,7 +51743,7 @@
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
 "fhB" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "fhK" = (
@@ -51692,8 +51812,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "flE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
+	dir = 10
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
@@ -51777,7 +51900,6 @@
 	dir = 8
 	},
 /obj/machinery/pipedispenser/disposal,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "fpr" = (
@@ -51800,6 +51922,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "fpF" = (
@@ -51817,10 +51942,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
 	dir = 10
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/cafeteria,
 /area/engineering/atmos)
 "frn" = (
@@ -51910,7 +52035,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Foyer";
 	req_access_txt = "10"
@@ -51919,13 +52043,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "fuH" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -52107,9 +52232,7 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "fAn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -52119,6 +52242,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "fAA" = (
@@ -52161,12 +52288,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "fCZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
+	dir = 8;
+	name = "Air to Distro"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -52222,9 +52351,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -52271,10 +52397,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "fFM" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -52298,9 +52420,18 @@
 /area/science/research)
 "fFR" = (
 /obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Entrance"
+	c_tag = "Atmospherics - Entrance";
+	pixel_y = 12
+	},
+/obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/engine/atmos";
+	dir = 1;
+	name = "Atmospherics APC";
+	pixel_y = 28
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -52310,9 +52441,11 @@
 /turf/open/space,
 /area/solars/port/aft)
 "fGc" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/engineering/atmos)
 "fGl" = (
 /obj/structure/chair,
@@ -52326,20 +52459,19 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "fHg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "fHh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
 "fHu" = (
@@ -52417,11 +52549,10 @@
 /turf/open/floor/plating,
 /area/cargo/miningoffice)
 "fKM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/main)
+/obj/structure/table,
+/obj/item/stock_parts/cell/potato,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "fLh" = (
 /obj/machinery/door/airlock/grunge,
 /obj/structure/cable/yellow{
@@ -52453,9 +52584,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "fLL" = (
@@ -52538,20 +52667,19 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "fNf" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "fNh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "fNk" = (
@@ -52644,10 +52772,11 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "fQZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engineering/main)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "fRj" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -52742,12 +52871,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "fUI" = (
@@ -52768,8 +52898,8 @@
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
 "fVg" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3,
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
 	dir = 4;
 	name = "Unfiltered & Air to Mix"
 	},
@@ -52845,7 +52975,7 @@
 	c_tag = "MiniSat Exterior - Aft";
 	network = list("minisat")
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "fWz" = (
@@ -52955,7 +53085,6 @@
 	dir = 8
 	},
 /obj/machinery/pipedispenser,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Entrance";
 	dir = 8
@@ -53260,9 +53389,7 @@
 	dir = 4;
 	sortType = 20
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "giv" = (
 /obj/structure/disposalpipe/segment{
@@ -53305,14 +53432,17 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -53322,6 +53452,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -53433,6 +53569,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/camera{
+	c_tag = "Research Division Circuitry Lab";
+	dir = 1;
+	network = list("ss13","rd")
+	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "goF" = (
@@ -53524,9 +53665,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "gsp" = (
@@ -53610,6 +53750,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "gub" = (
@@ -53629,10 +53770,10 @@
 	pixel_x = 9;
 	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "guR" = (
@@ -53649,6 +53790,9 @@
 	},
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -53667,11 +53811,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "gvV" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "gvY" = (
@@ -53795,7 +53936,7 @@
 /turf/open/floor/plasteel,
 /area/cargo/office)
 "gyR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "gzm" = (
@@ -53812,7 +53953,6 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "gzG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -53821,7 +53961,6 @@
 	id = "ceprivacy";
 	name = "privacy shutter"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "gzN" = (
@@ -53912,11 +54051,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/door/airlock/external{
 	dir = 4;
 	name = "Atmospherics External Airlock";
 	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -54088,12 +54229,14 @@
 /turf/open/floor/wood,
 /area/service/library)
 "gGH" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/obj/structure/trash_pile,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/atmos)
 "gGT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -54307,6 +54450,7 @@
 	dir = 1;
 	network = list("ss13","engine")
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/engine,
 /area/engineering/main)
 "gPG" = (
@@ -54459,6 +54603,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "gTN" = (
@@ -54500,10 +54647,11 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "gVf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/closet/bombcloset,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "gVv" = (
@@ -54658,11 +54806,11 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
@@ -54695,9 +54843,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "hbh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engineering/break_room)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "hbq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -54755,9 +54908,6 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "hdJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -54790,19 +54940,6 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"heu" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
-/area/engineering/main)
 "hfd" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/tile/brown{
@@ -54814,21 +54951,19 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "hfg" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Air to Ports"
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "hfv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -54852,9 +54987,11 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "hfU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engineering/main)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "hgy" = (
 /obj/machinery/computer/robotics{
 	dir = 8
@@ -54871,12 +55008,9 @@
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
 "hgV" = (
-/obj/structure/table/wood/fancy/red,
-/obj/item/reagent_containers/food/snacks/burger/fish{
-	pixel_x = -6;
-	pixel_y = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/carpet,
 /area/service/bar)
 "hhA" = (
@@ -55099,9 +55233,10 @@
 /area/medical/surgery)
 "hop" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "hoq" = (
@@ -55218,8 +55353,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -55279,9 +55417,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "hrn" = (
 /obj/structure/table/reinforced,
@@ -55356,8 +55492,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "hsG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
@@ -55417,6 +55556,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "huJ" = (
@@ -55449,12 +55589,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
-"hvd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/main)
 "hvi" = (
 /obj/machinery/camera{
 	c_tag = "Research Testing Range";
@@ -55669,23 +55803,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"hzY" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/bar)
 "hAr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -55705,9 +55822,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "hAM" = (
 /obj/machinery/airalarm{
@@ -55736,9 +55851,6 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "hBG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -55890,11 +56002,11 @@
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
 "hFa" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -55961,9 +56073,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -56011,7 +56121,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -56049,9 +56158,6 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "hKd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -56063,6 +56169,9 @@
 	c_tag = "MiniSat Exterior - Port Fore";
 	dir = 8;
 	network = list("minisat")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -56234,7 +56343,13 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "hNW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "hOA" = (
@@ -56316,9 +56431,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "hQA" = (
@@ -56352,9 +56464,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -56678,11 +56787,14 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "hZe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
 	req_access_txt = "24"
@@ -56690,7 +56802,7 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "hZk" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3{
 	dir = 1
 	},
 /turf/closed/wall/r_wall,
@@ -56766,15 +56878,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "ibn" = (
 /obj/structure/cable/yellow{
@@ -56787,13 +56891,6 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/cargo/storage)
-"ibJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "ibO" = (
 /obj/structure/chair{
 	dir = 1
@@ -56948,15 +57045,16 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/fore)
 "iiu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "iix" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -57034,9 +57132,6 @@
 /area/science/research)
 "ijW" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -57214,7 +57309,6 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/atmospherics,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
@@ -57289,9 +57383,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "irH" = (
@@ -57301,20 +57396,18 @@
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "irO" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "rdprivacy";
-	name = "privacy shutter"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "rdprivacy";
+	name = "privacy shutter"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
 "irY" = (
@@ -57432,9 +57525,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "iuW" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -57528,7 +57619,6 @@
 /area/cargo/warehouse)
 "ixs" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -57550,14 +57640,6 @@
 	},
 /turf/open/floor/plating,
 /area/service/chapel/main)
-"ixJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "ixL" = (
 /turf/closed/wall,
 /area/cargo/miningoffice)
@@ -57661,6 +57743,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "izZ" = (
@@ -57689,10 +57777,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
 	dir = 6
 	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "iAR" = (
@@ -57751,6 +57839,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "iDK" = (
@@ -57801,12 +57890,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/hop)
-"iET" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/main)
 "iFl" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide{
 	valve_open = 1
@@ -57820,7 +57903,6 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -57945,9 +58027,6 @@
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
 "iGQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -57957,6 +58036,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "iGV" = (
@@ -58055,12 +58135,15 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "iKH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Port";
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "iKQ" = (
@@ -58112,21 +58195,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "iMF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engineering/main)
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "iMH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "iMN" = (
@@ -58308,7 +58389,6 @@
 	name = "Engine Room";
 	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -58318,6 +58398,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -58361,14 +58443,11 @@
 "iUY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/structure/chair/stool/bar,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/structure/chair/stool/bar{
+	pixel_y = 8
 	},
+/turf/open/floor/wood,
 /area/service/bar)
 "iVb" = (
 /obj/structure/grille,
@@ -58424,8 +58503,11 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "iXR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
@@ -58434,10 +58516,10 @@
 	dir = 1;
 	name = "MiniSat Walkway Access"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "iYv" = (
@@ -58451,6 +58533,13 @@
 	dir = 8;
 	pixel_x = 14;
 	pixel_y = 4
+	},
+/obj/effect/turf_decal/loading_area{
+	icon_state = "steel_decals10"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4;
+	icon_state = "steel_decals10"
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
@@ -58505,7 +58594,7 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "jaL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -58649,20 +58738,23 @@
 /turf/open/floor/plating,
 /area/command/gateway)
 "jdV" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "jfa" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/cafeteria,
 /area/engineering/atmos)
 "jfi" = (
@@ -58734,9 +58826,15 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "jgc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engineering/gravity_generator)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "jgw" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Aft";
@@ -58753,11 +58851,21 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "jgy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engineering/break_room)
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/crowbar,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "jgE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -58800,9 +58908,6 @@
 /turf/open/floor/plating,
 /area/command/gateway)
 "jig" = (
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Evil Pete"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
@@ -58868,10 +58973,11 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "jje" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58995,6 +59101,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
 "jom" = (
@@ -59026,20 +59133,13 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "jor" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
-/area/engineering/atmos)
+/area/science/mixing)
 "joE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "joP" = (
 /obj/machinery/door/window/southleft{
 	name = "Bar Delivery";
@@ -59146,9 +59246,6 @@
 	dir = 8;
 	network = list("minisat")
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -3;
@@ -59204,7 +59301,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "jtX" = (
@@ -59287,10 +59390,10 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "jwC" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "jwE" = (
@@ -59346,7 +59449,10 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
 "jxw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 0;
+	name = "External to Filter"
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -59360,8 +59466,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -59397,17 +59506,24 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "jyo" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/table,
+/obj/item/clothing/glasses/science{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/science{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "jyv" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/high,
@@ -59443,7 +59559,7 @@
 	dir = 8;
 	network = list("minisat")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -59643,10 +59759,6 @@
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
 	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Port";
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -59752,6 +59864,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "jKl" = (
@@ -59764,6 +59882,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/camera_film,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -59823,7 +59943,12 @@
 	name = "MiniSat Space Access Airlock";
 	req_one_access_txt = "32;19"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "jLN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59888,15 +60013,12 @@
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/hos)
 "jNm" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Space Access Airlock";
 	req_one_access_txt = "32;19"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
@@ -59946,8 +60068,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "jNA" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1,
 /turf/open/floor/plating/airless,
 /area/ai_monitored/aisat/exterior)
 "jOk" = (
@@ -59968,18 +60090,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "jPn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60176,10 +60290,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "jSy" = (
@@ -60268,13 +60383,13 @@
 /turf/closed/wall,
 /area/commons/locker)
 "jUF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "jVR" = (
@@ -60380,7 +60495,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "kbS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "kbX" = (
@@ -60427,13 +60542,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
 "kdi" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/r_wall,
+/area/science/circuit)
 "kdB" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
@@ -60591,9 +60702,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -60603,6 +60711,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -60629,6 +60740,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -60679,12 +60796,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "kiW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "kje" = (
@@ -60811,18 +60923,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/rack/shelf,
-/obj/item/airlock_painter{
-	pixel_y = 3
-	},
-/obj/item/airlock_painter/decal{
-	pixel_y = -3
-	},
-/obj/item/airlock_painter/decal/tile{
-	pixel_y = -9
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
@@ -60903,9 +61009,6 @@
 /turf/open/floor/plasteel,
 /area/commons/dorms)
 "krO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -60915,6 +61018,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -60944,12 +61050,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "ksZ" = (
@@ -60988,8 +61093,8 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "ktI" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "ktS" = (
@@ -60999,15 +61104,20 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "ktV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/closed/wall,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "kuk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engineering/break_room)
@@ -61120,7 +61230,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "kwE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/shower{
 	dir = 8
 	},
@@ -61130,7 +61239,6 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "kwP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/plasteel,
@@ -61158,12 +61266,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "kxY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "kyq" = (
@@ -61200,7 +61307,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "kyJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -61345,6 +61452,9 @@
 	dir = 8;
 	name = "Port to Filter"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "kBm" = (
@@ -61360,10 +61470,10 @@
 	},
 /area/command/gateway)
 "kBn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "kBr" = (
@@ -61525,14 +61635,17 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -61625,15 +61738,11 @@
 	},
 /area/command/gateway)
 "kHk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/main)
+/turf/open/floor/engine,
+/area/science/mixing)
 "kHv" = (
 /obj/item/flashlight/lamp/green{
 	pixel_x = 1;
@@ -61705,17 +61814,15 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "kJQ" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "kKa" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "kKl" = (
@@ -61753,10 +61860,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "kLa" = (
@@ -61764,12 +61871,6 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
-"kLr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "kLD" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -61782,12 +61883,21 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "kLP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/power/apc{
+	areastring = "/area/science/mixing";
+	dir = 4;
+	name = "Toxins Lab APC";
+	pixel_x = 26
+	},
+/obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/engineering/main)
+/area/science/mixing)
 "kMq" = (
 /obj/item/flashlight/lantern{
 	pixel_y = 7
@@ -61822,12 +61932,11 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "kNr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "kNs" = (
@@ -61843,16 +61952,16 @@
 /turf/closed/wall,
 /area/commons/fitness/recreation)
 "kNM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
 	},
-/obj/item/stack/tile/plasteel{
-	pixel_y = 12
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engineering/break_room)
 "kOt" = (
 /obj/machinery/requests_console{
@@ -61887,7 +61996,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -61976,22 +62085,22 @@
 	dir = 8;
 	name = "N2O to Pure"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "kRP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "kSn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -62041,15 +62150,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "kSF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
+/obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "kSV" = (
@@ -62187,11 +62297,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/engineering/atmos)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "kXd" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -62242,11 +62357,15 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "kXS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/light_switch{
+	pixel_y = 25
 	},
-/turf/open/floor/plasteel/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/suit_storage_unit/rd,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/science/mixing)
 "kYl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/yellowsiding/corner{
@@ -62439,6 +62558,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plating,
 /area/engineering/main)
 "lcv" = (
@@ -62478,11 +62598,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
 "ldb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/engineering/atmos)
 "lde" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -62518,13 +62637,7 @@
 /area/commons/locker)
 "ldI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Air to External Air Ports"
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "lep" = (
@@ -62832,9 +62945,6 @@
 /area/command/bridge)
 "lod" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -62842,6 +62952,10 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "lpm" = (
@@ -62859,7 +62973,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -62895,22 +63009,19 @@
 /area/cargo/office)
 "lrM" = (
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
 	req_access_txt = "32"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "lrV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -62952,14 +63063,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
 "ltg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "lty" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -63001,8 +63112,8 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
@@ -63055,11 +63166,9 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
 "lvR" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
 "lvV" = (
@@ -63337,11 +63446,11 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/ai_slipper{
 	uses = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -63373,9 +63482,14 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
 "lBY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -63464,9 +63578,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -63497,12 +63608,13 @@
 	name = "Gravity Generator Room";
 	req_access_txt = "19;23"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "lGk" = (
@@ -63541,9 +63653,6 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "lHN" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Port to External"
@@ -63723,9 +63832,6 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "lOi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -63772,7 +63878,7 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "lOJ" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
+/obj/machinery/atmospherics/pipe/manifold/green/visible/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -63874,6 +63980,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "lRj" = (
@@ -63927,15 +64034,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "lTr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark/corner,
 /area/engineering/break_room)
 "lTz" = (
@@ -63994,17 +64100,21 @@
 /obj/machinery/door/window/westleft{
 	req_access_txt = "24"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "lUs" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engineering/atmos)
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "lUB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -64018,7 +64128,9 @@
 /turf/open/floor/plating,
 /area/command/bridge)
 "lUC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "lUO" = (
@@ -64059,9 +64171,8 @@
 /area/commons/vacant_room/office)
 "lWq" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 8
-	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
 /area/service/bar)
 "lWX" = (
@@ -64075,16 +64186,16 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
 "lWY" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Server Room"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Server Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "lXj" = (
@@ -64119,21 +64230,19 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "lXt" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/engine,
+/area/science/mixing)
 "lYc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Office";
 	req_access_txt = "56"
@@ -64144,24 +64253,21 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
 /area/command/heads_quarters/ce)
 "lYe" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Air to Distro"
-	},
 /obj/machinery/airalarm{
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Distro Loop"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -64169,9 +64275,7 @@
 /area/engineering/atmos)
 "lYI" = (
 /obj/effect/landmark/xmastree,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "lYW" = (
 /obj/effect/turf_decal/loading_area{
@@ -64222,12 +64326,16 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "maO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
-	},
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -64504,7 +64612,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "mgJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "mgT" = (
@@ -64513,12 +64623,15 @@
 /turf/closed/wall,
 /area/space/nearstation)
 "mhG" = (
-/obj/machinery/holopad,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/engine,
+/area/science/mixing)
 "mhW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -64570,18 +64683,6 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
-"mjp" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/bar)
 "mjJ" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line{
@@ -64624,12 +64725,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/storage)
-"mlA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/main)
 "mlH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/sand/plating,
@@ -64664,6 +64759,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "mmH" = (
@@ -64696,14 +64800,12 @@
 /area/ai_monitored/aisat/exterior)
 "mnr" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/landmark/start/cyborg,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "moO" = (
@@ -64776,11 +64878,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
@@ -64798,12 +64906,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "mqq" = (
@@ -64843,16 +64949,16 @@
 /turf/open/floor/plating,
 /area/command/gateway)
 "msu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/aisat/exterior)
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/engine,
+/area/science/mixing)
 "msv" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Gravity Generator Area";
 	req_access_txt = "19; 61"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "msx" = (
@@ -64860,13 +64966,13 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
 "msI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/service/bar)
 "mte" = (
@@ -64896,6 +65002,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "mtJ" = (
@@ -64914,10 +65023,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
 "mtM" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Mix"
-	},
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "muJ" = (
@@ -65023,7 +65129,6 @@
 /area/command/corporate_showroom)
 "mxo" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -65053,20 +65158,17 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "mxR" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/open/floor/engine,
 /area/science/mixing)
 "mxT" = (
 /obj/machinery/conveyor{
@@ -65147,12 +65249,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
-"mzH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/main)
 "mAa" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -65169,9 +65265,6 @@
 /area/command/heads_quarters/cmo)
 "mAj" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -65290,11 +65383,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
-"mDX" = (
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/bar)
 "mEe" = (
 /obj/structure/sink{
 	dir = 8;
@@ -65358,13 +65446,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
@@ -65373,10 +65463,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/security/prison)
-"mFr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/engineering/main)
 "mFH" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/freezer,
@@ -65436,16 +65522,8 @@
 /turf/closed/wall/r_wall,
 /area/commons/storage/tools)
 "mHB" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/chair/stool/bar,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "mHZ" = (
 /obj/effect/landmark/xeno_spawn,
@@ -65459,9 +65537,6 @@
 	dir = 8;
 	pixel_x = 9;
 	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -65483,15 +65558,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "mIR" = (
 /obj/structure/cable/yellow{
@@ -65648,16 +65715,15 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "mNX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "mOc" = (
@@ -65693,6 +65759,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_x = -4;
+	pixel_y = 6
+	},
 /turf/open/floor/plating,
 /area/service/bar)
 "mPQ" = (
@@ -65780,9 +65850,14 @@
 	},
 /area/ai_monitored/command/nuke_storage)
 "mSB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -66022,13 +66097,14 @@
 /turf/open/floor/plasteel,
 /area/command/bridge)
 "mZD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "mZQ" = (
@@ -66060,7 +66136,7 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "naf" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
 /turf/closed/wall,
@@ -66251,7 +66327,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "nik" = (
@@ -66272,6 +66347,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "njt" = (
@@ -66383,13 +66459,11 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "nmt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "nmx" = (
@@ -66421,7 +66495,7 @@
 	dir = 8;
 	name = "MiniSat Airlock Access"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "nmO" = (
@@ -66434,10 +66508,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -66483,10 +66553,6 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "npo" = (
-/obj/machinery/door/airlock/maintenance{
-	dir = 8;
-	req_one_access_txt = "12;25;46"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
@@ -66499,12 +66565,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 8;
+	req_one_access_txt = "12;25;46"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"npE" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "nqx" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light_switch{
@@ -66562,8 +66631,6 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "nry" = (
-/obj/structure/table,
-/obj/item/camera,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -66731,34 +66798,29 @@
 /obj/item/folder,
 /obj/item/folder,
 /obj/item/pen,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "nzH" = (
 /turf/open/floor/wood,
 /area/service/hydroponics/garden)
 "nAl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/space,
 /area/ai_monitored/aisat/exterior)
 "nAB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/engine,
+/area/science/mixing)
 "nAD" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/cargo_technician,
@@ -66799,7 +66861,7 @@
 /turf/open/floor/wood,
 /area/service/library)
 "nCa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -66843,9 +66905,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -66895,11 +66954,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "nFz" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "nFG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+/obj/effect/turf_decal/loading_area{
+	dir = 10;
+	icon_state = "steel_decals3"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 1;
+	icon_state = "steel_decals3"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -66951,12 +67020,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"nGs" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/service/bar)
 "nHn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67030,7 +67093,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "nJr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "nKi" = (
@@ -67113,7 +67176,7 @@
 	icon_state = "right";
 	name = "MiniSat Airlock Access"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -67257,9 +67320,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
@@ -67302,11 +67367,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
@@ -67447,18 +67512,14 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "nUC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/open/floor/plasteel,
-/area/engineering/break_room)
+/area/science/robotics/lab)
 "nUI" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -67602,6 +67663,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "nYJ" = (
@@ -67713,18 +67783,17 @@
 /turf/open/floor/plasteel,
 /area/command/teleporter)
 "oag" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Toxins - Mixing Area";
+	dir = 8;
+	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
+/turf/open/floor/engine,
+/area/science/mixing)
 "oak" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -67759,15 +67828,6 @@
 	},
 /area/command/gateway)
 "oay" = (
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/engine/atmos";
-	dir = 1;
-	name = "Atmospherics APC";
-	pixel_y = 28
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/machinery/light_switch{
 	pixel_x = -26
 	},
@@ -67857,9 +67917,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "oda" = (
 /obj/machinery/door/poddoor/preopen{
@@ -67932,9 +67990,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "odq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/area/science/server)
 "ods" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -68188,10 +68248,10 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
 "okm" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible/layer3{
 	dir = 8
 	},
-/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "okn" = (
@@ -68248,22 +68308,24 @@
 	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "olW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "omb" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -68364,15 +68426,7 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/locker)
 "ooB" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "ooH" = (
@@ -68380,9 +68434,11 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "opc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -68516,6 +68572,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "ott" = (
@@ -68642,10 +68701,10 @@
 /turf/open/floor/plating/airless,
 /area/solars/starboard/fore)
 "oyV" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 6
 	},
-/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "ozl" = (
@@ -68777,7 +68836,12 @@
 /turf/open/space,
 /area/solars/port/fore)
 "oBF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "oBW" = (
@@ -68818,9 +68882,6 @@
 "oCy" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -68956,21 +69017,10 @@
 /area/service/chapel/main)
 "oJt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+	dir = 10
 	},
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engineering/gravity_generator)
+/turf/closed/wall/r_wall,
+/area/science/server)
 "oJO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -69013,6 +69063,10 @@
 	},
 /obj/machinery/holopad,
 /obj/item/beacon,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "oKD" = (
@@ -69140,17 +69194,11 @@
 /turf/open/floor/plasteel,
 /area/command/gateway)
 "oOQ" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
+/turf/closed/wall/r_wall,
+/area/science/server)
 "oOU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -69438,18 +69486,20 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "oVa" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plasteel,
-/area/science/mixing)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "oVF" = (
 /obj/structure/sign/carts,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "oVH" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
 	name = "Waste to Filter"
 	},
 /turf/open/floor/plasteel,
@@ -69557,10 +69607,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "oZU" = (
@@ -69592,9 +69645,6 @@
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
 "pan" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -69605,14 +69655,14 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/transit_tube/station{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -69644,7 +69694,6 @@
 /turf/open/floor/carpet/gato,
 /area/commons/dorms)
 "paS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -69657,6 +69706,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "pbc" = (
@@ -69666,10 +69717,14 @@
 	},
 /obj/structure/table,
 /obj/item/storage/box/donkpockets/donkpocketpizza,
+/obj/item/kitchen/fork{
+	pixel_x = -8;
+	pixel_y = 3
+	},
 /turf/open/floor/carpet/black,
 /area/science/research)
 "pbQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/closed/wall,
 /area/ai_monitored/aisat/exterior)
 "pcc" = (
@@ -69695,11 +69750,20 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "pcs" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
+/obj/structure/sign/warning/biohazard{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "pct" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -69757,14 +69821,14 @@
 	name = "Engineering Security APC";
 	pixel_x = -24
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
@@ -69849,13 +69913,14 @@
 /area/cargo/sorting)
 "pfi" = (
 /obj/machinery/door/poddoor/preopen{
+	dir = 4;
 	id = "rdprivacy";
 	name = "privacy shutter"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
 "pfp" = (
@@ -69989,6 +70054,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "pjG" = (
@@ -70013,10 +70081,16 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "pjR" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70095,7 +70169,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "plN" = (
@@ -70210,8 +70284,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "pnM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
@@ -70327,17 +70401,30 @@
 /turf/open/floor/carpet/orange,
 /area/commons/locker)
 "pse" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "psh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/ai_slipper{
 	uses = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -70445,9 +70532,14 @@
 /area/maintenance/starboard)
 "pvK" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -70639,9 +70731,15 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
+/obj/structure/rack/shelf,
+/obj/item/airlock_painter{
+	pixel_y = 3
+	},
+/obj/item/airlock_painter/decal{
+	pixel_y = -3
+	},
+/obj/item/airlock_painter/decal/tile{
+	pixel_y = -9
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
@@ -70688,14 +70786,16 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/hop)
 "pCg" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "pCC" = (
@@ -70724,10 +70824,12 @@
 /turf/open/floor/carpet/red,
 /area/commons/locker)
 "pCS" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "pCV" = (
@@ -70918,9 +71020,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "pHX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -70930,6 +71029,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "pIc" = (
@@ -70948,16 +71048,21 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "pIJ" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/maintenance/starboard/aft";
+	name = "Starboard Quarter Maintenance APC";
+	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
 	},
-/area/service/bar)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "pJd" = (
 /obj/structure/window/reinforced,
 /obj/machinery/holopad,
@@ -71045,19 +71150,6 @@
 "pLf" = (
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
-"pLx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
-/area/engineering/main)
 "pMd" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
@@ -71143,8 +71235,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
 "pPS" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -71154,9 +71246,6 @@
 	dir = 8;
 	pixel_x = 9;
 	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -71194,9 +71283,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "pRA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -71259,9 +71346,6 @@
 /area/service/hydroponics/garden)
 "pTr" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "pTI" = (
@@ -71317,6 +71401,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -71370,19 +71458,19 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "pVL" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/aft)
 "pVM" = (
 /obj/structure/window/reinforced{
@@ -71430,17 +71518,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "pXC" = (
-/obj/effect/spawner/lootdrop/keg,
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
 /obj/structure/table/wood/fancy/red,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_x = 4;
+	pixel_y = 6
 	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "pXT" = (
 /obj/structure/window/reinforced,
@@ -71544,7 +71627,7 @@
 	dir = 1;
 	network = list("minisat")
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "qaJ" = (
@@ -71717,12 +71800,12 @@
 /area/maintenance/port)
 "qgP" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -71754,15 +71837,13 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "qha" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 8
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "qhe" = (
@@ -71922,6 +72003,18 @@
 	pixel_y = 7
 	},
 /obj/item/storage/belt/utility,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "qmj" = (
@@ -72047,16 +72140,26 @@
 	pixel_y = 4
 	},
 /obj/structure/table/glass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "qnH" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/starboard/aft)
 "qoi" = (
 /obj/structure/sign/poster/random,
 /turf/closed/wall,
@@ -72076,7 +72179,9 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
 "qoD" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "qoW" = (
@@ -72145,8 +72250,8 @@
 /turf/open/floor/plating,
 /area/command/bridge)
 "qpQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
@@ -72253,10 +72358,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -72408,9 +72516,6 @@
 "qAr" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -72564,9 +72669,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/machinery/shower{
 	dir = 8;
 	name = "emergency shower"
@@ -72593,27 +72695,20 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "qDt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engineering/main)
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall,
+/area/maintenance/aft)
 "qDu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "qDJ" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
 "qEc" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
@@ -72706,7 +72801,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "qHe" = (
@@ -72763,13 +72859,11 @@
 	},
 /area/command/heads_quarters/rd)
 "qIq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "qID" = (
@@ -72780,7 +72874,6 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
 "qIM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/computer/rdconsole/production{
 	dir = 1
 	},
@@ -72797,7 +72890,6 @@
 	name = "Engine Room";
 	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -72805,6 +72897,8 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -72971,9 +73065,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "qPs" = (
 /obj/effect/turf_decal/bot,
@@ -73176,9 +73268,13 @@
 /area/commons/toilet/restrooms)
 "qUd" = (
 /obj/machinery/meter/atmos/distro_loop,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Distro Loop";
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -73216,9 +73312,8 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "qVE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Distro"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -73284,13 +73379,17 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "qWu" = (
-/obj/machinery/smartfridge/drinks{
-	icon_state = "boozeomat"
-	},
+/obj/machinery/vending/boozeomat/all_access,
 /turf/closed/wall,
 /area/service/bar)
 "qWR" = (
 /obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -73529,11 +73628,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "rcO" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -73557,15 +73659,15 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
 "rdg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /obj/machinery/door/airlock/atmos/glass{
 	dir = 8;
 	name = "Distribution Loop";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "rdv" = (
@@ -73685,9 +73787,7 @@
 	},
 /area/construction/storage_wing)
 "rgc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/aisat/exterior)
 "rgr" = (
@@ -73905,6 +74005,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 6
+	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Air to Pure"
@@ -73932,13 +74035,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
 "rms" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "rmu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -74023,6 +74127,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "roz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "rpQ" = (
@@ -74051,18 +74158,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "rqG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -74170,7 +74269,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
@@ -74305,19 +74403,18 @@
 /turf/open/floor/carpet,
 /area/command/corporate_showroom)
 "ryl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engineering/main)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ryM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Starboard";
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
@@ -74393,12 +74490,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "rzT" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
@@ -74409,9 +74500,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "rzX" = (
 /obj/structure/chair/office/light{
@@ -74541,9 +74630,6 @@
 "rGv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -74784,19 +74870,14 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "rMA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Distro to Waste"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	dir = 8;
+	name = "Distro to Waste"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
@@ -74828,7 +74909,7 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "rNi" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -74994,9 +75075,15 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "rSL" = (
-/obj/machinery/vending/mealdor,
-/turf/open/floor/plasteel,
-/area/science/mixing)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "rSO" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75053,6 +75140,11 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8;
+	icon_state = "drain";
+	name = "drain"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -75183,10 +75275,10 @@
 /obj/machinery/door/window{
 	name = "MiniSat Walkway Access"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "rYE" = (
@@ -75242,11 +75334,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/aft)
@@ -75272,18 +75367,22 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "saP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/aisat/exterior)
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "saR" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/soda_cans/pwr_game{
@@ -75295,13 +75394,18 @@
 	},
 /area/service/hydroponics/garden)
 "saT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
-/area/engineering/main)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "sbg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -75418,7 +75522,6 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/radiation,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
@@ -75432,9 +75535,6 @@
 "sdQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -75498,7 +75598,6 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -75545,10 +75644,13 @@
 /turf/open/floor/plasteel/dark,
 /area/command/gateway)
 "sfM" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/item/beacon,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "sfV" = (
@@ -75588,24 +75690,22 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "shE" = (
-/obj/structure/window/reinforced{
+/obj/machinery/light{
 	dir = 1;
-	pixel_y = 1
+	pixel_y = 12
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/aisat/exterior)
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "shK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/closed/wall,
-/area/engineering/atmos)
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "siC" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -75723,10 +75823,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel{
 	dir = 1
 	},
@@ -75745,8 +75846,8 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/primary)
 "slh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/space,
 /area/ai_monitored/aisat/exterior)
 "sln" = (
@@ -75895,7 +75996,6 @@
 "spp" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "spx" = (
@@ -76230,6 +76330,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/machinery/vending/assist,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "sBz" = (
@@ -76262,15 +76363,15 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
 "sCL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engineering/main)
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "sCN" = (
 /obj/structure/dresser,
 /obj/item/flashlight/lamp/green{
@@ -76396,11 +76497,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "sGo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "sGF" = (
@@ -76517,13 +76618,28 @@
 /area/engineering/atmos)
 "sJE" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/door/poddoor/preopen{
 	dir = 4;
 	id = "toxins_blastdoor";
 	name = "biohazard containment door"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -76567,7 +76683,9 @@
 /turf/closed/wall,
 /area/engineering/atmos)
 "sKz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "sKT" = (
@@ -76592,9 +76710,6 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "sLW" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "sMe" = (
@@ -76684,10 +76799,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "sPC" = (
@@ -76769,14 +76883,17 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "sRX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -76849,12 +76966,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
-"sUc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "sUd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76873,9 +76984,11 @@
 	pixel_x = -22;
 	pixel_y = 22
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/service/bar)
 "sVh" = (
@@ -76934,7 +77047,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/service/kitchen)
 "sWZ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "sXr" = (
@@ -76995,8 +77108,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -77019,16 +77135,10 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "sZJ" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
+/obj/structure/chair/stool/bar{
+	pixel_x = -4
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "sZM" = (
 /obj/machinery/power/apc{
@@ -77088,9 +77198,6 @@
 "taH" = (
 /obj/machinery/firealarm{
 	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -77184,9 +77291,6 @@
 /area/command/bridge)
 "tdS" = (
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -77253,8 +77357,9 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "tfk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	dir = 1;
+	name = "Mix to Distro"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -77344,11 +77449,11 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "thi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "thm" = (
@@ -77372,12 +77477,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tie" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Nitrogen Outlet"
-	},
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/layer3{
+	dir = 1;
+	name = "Nitrogen Outlet"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
@@ -77441,15 +77546,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine/cult,
 /area/service/library)
-"tiT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engineering/main)
 "tjd" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -77528,14 +77624,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
-"tlF" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/service/bar)
 "tmg" = (
 /turf/closed/wall,
 /area/command/bridge)
@@ -77564,6 +77652,9 @@
 "tnh" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
@@ -77805,9 +77896,6 @@
 	},
 /area/science/misc_lab/range)
 "txb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -77817,6 +77905,9 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Control Room";
 	req_one_access_txt = "19; 61"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
@@ -77864,6 +77955,12 @@
 /area/ai_monitored/aisat/exterior)
 "tyC" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -78018,9 +78115,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 0;
-	name = "External to Filter"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
@@ -78030,7 +78126,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "tFJ" = (
@@ -78102,16 +78204,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"tHP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engineering/main)
 "tHZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet/green,
@@ -78226,6 +78318,12 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -78349,7 +78447,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
 "tNF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "tNG" = (
@@ -78384,11 +78484,13 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "tNY" = (
-/obj/machinery/holopad,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "tOg" = (
@@ -78433,13 +78535,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "tPJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/gravity_generator)
 "tPT" = (
@@ -78479,9 +78578,6 @@
 	areastring = "/area/ai_monitored/storage/satellite";
 	name = "MiniSat Maint APC";
 	pixel_y = -26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/structure/cable/yellow,
 /obj/item/stack/sheet/mineral/plasma{
@@ -78884,6 +78980,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/camera,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -79001,6 +79099,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
+/obj/machinery/door/airlock/public/glass{
+	dir = 8;
+	name = "Bar"
+	},
 /turf/open/floor/carpet,
 /area/service/bar)
 "uew" = (
@@ -79030,6 +79132,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -79101,7 +79206,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "uhB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -79115,7 +79220,6 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/engine,
 /area/engineering/main)
 "uih" = (
@@ -79196,14 +79300,15 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ujb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
@@ -79251,9 +79356,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "ulQ" = (
 /obj/machinery/door/window/brigdoor{
@@ -79402,9 +79505,6 @@
 /area/engineering/atmos)
 "uot" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/power/port_gen/pacman,
@@ -79461,9 +79561,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "uqh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79590,20 +79688,14 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/engineering/main)
-"usC" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "usL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plating,
 /area/cargo/office)
 "usM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -79638,20 +79730,19 @@
 /area/commons/dorms)
 "uuf" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/engineering/glass{
 	dir = 4;
 	name = "Supermatter Engine";
 	req_access_txt = "10"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"uun" = (
-/obj/machinery/vending/assist,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "uuu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -79781,8 +79872,8 @@
 /area/hallway/secondary/service)
 "uyH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
@@ -79900,10 +79991,10 @@
 /turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "uED" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "uFM" = (
@@ -80068,12 +80159,6 @@
 /turf/open/floor/plasteel,
 /area/commons/storage/tools)
 "uJR" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/machinery/light_switch{
 	pixel_x = -22
 	},
@@ -80097,6 +80182,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
 "uLv" = (
@@ -80118,6 +80207,17 @@
 "uMQ" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 6;
+	icon_state = "steel_decals6"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 5;
+	icon_state = "steel_decals4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/bar)
@@ -80231,18 +80331,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
-"uTg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/engineering/atmos)
 "uTn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "2-4"
 	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/gravity_generator)
 "uTQ" = (
@@ -80278,6 +80375,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -80382,7 +80482,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
 	},
@@ -80483,6 +80582,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "uZF" = (
@@ -80490,8 +80590,8 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -80612,9 +80712,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "vdh" = (
@@ -80689,9 +80786,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
-	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "ver" = (
@@ -80715,6 +80809,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -80795,10 +80895,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vfZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/shower{
 	dir = 4
 	},
@@ -80807,6 +80903,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -80873,16 +80972,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solars/starboard/fore)
-"vhG" = (
-/obj/structure/table/glass,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "vhM" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
@@ -80950,10 +81039,12 @@
 	},
 /area/command/heads_quarters/rd)
 "vjV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "vkg" = (
@@ -81038,30 +81129,15 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
-"vmm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
 "vms" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "vmE" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -81132,9 +81208,11 @@
 /turf/open/floor/plating,
 /area/service/chapel/main)
 "vpQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
@@ -81180,6 +81258,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "vsk" = (
@@ -81316,6 +81396,9 @@
 	pixel_y = 21
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "vwK" = (
@@ -81341,10 +81424,8 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/port)
 "vxg" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "vxN" = (
@@ -81411,6 +81492,12 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "vzO" = (
@@ -81434,13 +81521,20 @@
 	sortType = 4
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "vAQ" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
+	dir = 4;
 	id = "researchrangeshutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/misc_lab/range)
 "vBd" = (
@@ -81481,19 +81575,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/commons/toilet/restrooms)
 "vCf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/engine/break_room";
 	name = "Engineering Foyer APC";
 	pixel_x = -1;
 	pixel_y = -26
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/light,
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "vCg" = (
@@ -81645,16 +81734,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/jukebox,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "vGk" = (
 /obj/machinery/power/terminal,
@@ -81682,14 +81763,15 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "vGP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -81790,10 +81872,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
-"vLD" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "vLV" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -81810,10 +81888,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
-"vLX" = (
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "vMm" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2";
@@ -81927,7 +82001,6 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
 	pixel_y = -29
@@ -81980,10 +82053,10 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "vOz" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/green/visible/layer3{
 	dir = 1
 	},
-/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "vOQ" = (
@@ -81992,6 +82065,7 @@
 /area/engineering/atmos)
 "vPE" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "vPR" = (
@@ -82039,10 +82113,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "vRu" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "vRz" = (
@@ -82068,7 +82139,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -82248,13 +82322,16 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
 "vXi" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "vXk" = (
@@ -82365,7 +82442,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "vZw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -82378,6 +82454,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "vZL" = (
@@ -82407,15 +82485,7 @@
 	pixel_y = -22
 	},
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "waU" = (
 /obj/machinery/power/apc{
@@ -82428,9 +82498,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -82507,7 +82574,8 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -82520,6 +82588,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -82545,9 +82616,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = 26
@@ -82561,6 +82629,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -82621,14 +82693,31 @@
 /turf/open/floor/carpet,
 /area/service/chapel/main)
 "wfY" = (
-/obj/structure/table,
-/obj/item/camera_film,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/rack/shelf,
+/obj/item/toner{
+	pixel_y = 14
+	},
+/obj/item/toner{
+	pixel_y = 4
+	},
+/obj/item/toner{
+	pixel_y = 2
+	},
+/obj/item/toner{
+	pixel_y = -6
+	},
+/obj/item/toner{
+	pixel_y = -8
+	},
+/obj/item/toner{
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
@@ -82652,10 +82741,6 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "wgN" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -82663,6 +82748,11 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
+	dir = 4
+	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "whB" = (
@@ -82943,12 +83033,7 @@
 	pixel_y = 28
 	},
 /obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "woJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -82975,13 +83060,10 @@
 /turf/open/space,
 /area/solars/starboard/aft)
 "wpo" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
+/obj/structure/chair/stool/bar{
+	pixel_y = 8
 	},
-/obj/structure/chair/stool/bar,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "wpz" = (
 /obj/effect/turf_decal/bot{
@@ -83013,15 +83095,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/carpet/black,
 /area/service/bar)
 "wqi" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -83038,10 +83113,10 @@
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
 "wqG" = (
-/obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "wqL" = (
@@ -83049,9 +83124,6 @@
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -28
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/machinery/computer/monitor{
 	dir = 1
@@ -83424,13 +83496,12 @@
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
 "wAs" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "wAX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -83447,12 +83518,12 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "wBE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera{
 	c_tag = "Engineering - Transit Tube Access";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
 "wBK" = (
@@ -83706,15 +83777,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/turf/open/floor/wood,
 /area/service/bar)
 "wGv" = (
 /obj/machinery/computer/atmos_control/tank/toxin_tank{
@@ -83827,16 +83893,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
-"wKg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/closed/wall,
-/area/engineering/atmos)
-"wKo" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/closed/wall/r_wall,
-/area/science/circuit)
 "wKu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -83916,10 +83972,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wMJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/layer3{
 	name = "Air to Mix"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer3{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -84001,8 +84057,8 @@
 	pixel_x = 5;
 	pixel_y = -1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
@@ -84239,12 +84295,10 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
 "wTk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "wTI" = (
@@ -84279,9 +84333,11 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "wUI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
-	dir = 1
+/obj/item/reagent_containers/food/snacks/burger/fish{
+	pixel_x = -6;
+	pixel_y = 4
 	},
+/obj/structure/table/wood/fancy/red,
 /turf/open/floor/carpet,
 /area/service/bar)
 "wUL" = (
@@ -84471,25 +84527,20 @@
 /area/commons/locker)
 "wZn" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "wZw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "wZB" = (
@@ -84629,13 +84680,12 @@
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
 "xbR" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "xbT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -84650,10 +84700,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "xcA" = (
@@ -84695,7 +84744,6 @@
 /obj/item/folder/blue{
 	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/pen,
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 1;
@@ -84793,8 +84841,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
@@ -84810,6 +84858,10 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "xlc" = (
@@ -84942,7 +84994,7 @@
 /turf/open/floor/plasteel,
 /area/security/office)
 "xnt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -85005,16 +85057,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/locker)
-"xov" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engineering/break_room)
 "xpx" = (
 /obj/item/candle/infinite{
 	pixel_x = -10;
@@ -85060,12 +85102,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
-"xqi" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "xqj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -85106,11 +85142,11 @@
 /turf/open/floor/wood,
 /area/service/hydroponics/garden)
 "xqW" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "xrc" = (
@@ -85123,11 +85159,9 @@
 /turf/open/floor/wood,
 /area/service/library)
 "xro" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "xrw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -85198,6 +85232,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "xtl" = (
@@ -85229,16 +85264,29 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "xuf" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/door/poddoor/preopen{
 	dir = 4;
 	id = "toxins_blastdoor";
 	name = "biohazard containment door"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -85265,10 +85313,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
 "xvg" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/gravity_generator)
 "xvm" = (
@@ -85348,13 +85396,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
-"xxf" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "xxq" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -85450,10 +85491,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/service/library)
-"xAp" = (
-/obj/structure/chair/comfy,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "xAs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -85588,7 +85625,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side,
-/area/hallway/primary/central)
+/area/science/research)
 "xDS" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
@@ -85621,12 +85658,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"xDY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/aisat/exterior)
 "xDZ" = (
 /obj/effect/landmark/start/librarian,
 /obj/structure/chair/office/dark{
@@ -85691,8 +85722,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -85856,16 +85890,9 @@
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
 "xKw" = (
-/obj/structure/chair/stool/bar,
 /obj/machinery/camera{
 	c_tag = "Bar";
 	pixel_y = 12
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
 	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/crew_quarters/bar";
@@ -85876,9 +85903,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/structure/chair/stool/bar{
+	pixel_x = -4
 	},
+/turf/open/floor/wood,
 /area/service/bar)
 "xKG" = (
 /obj/machinery/door/firedoor,
@@ -85890,11 +85918,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	dir = 1
@@ -85950,7 +85981,6 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "xLR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -85975,18 +86005,20 @@
 /turf/open/floor/wood,
 /area/service/library)
 "xMk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 5
+	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/aisat/exterior)
 "xMl" = (
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "xMA" = (
@@ -86024,24 +86056,23 @@
 /turf/open/floor/wood,
 /area/service/library)
 "xNe" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/item/stack/tile/plasteel{
-	pixel_x = 5;
-	pixel_y = 14
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engineering/break_room)
 "xNr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer3{
+	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
@@ -86136,11 +86167,12 @@
 	name = "Engineering Security Doors"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "xPG" = (
@@ -86198,6 +86230,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
 "xQP" = (
@@ -86221,11 +86259,15 @@
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
 "xRM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -86313,6 +86355,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engineering/break_room)
 "xUs" = (
@@ -86355,18 +86401,18 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "xVh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
@@ -86395,9 +86441,6 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "xVP" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
 	dir = 4
@@ -86441,14 +86484,14 @@
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "xXs" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /turf/open/floor/plating,
 /area/engineering/gravity_generator)
 "xXI" = (
@@ -86694,12 +86737,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ydu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/medical/morgue)
 "ydB" = (
 /obj/structure/showcase/machinery/microwave{
 	desc = "The famous GATO microwave, the multi-purpose cooking appliance every station needs! This one appears to be drawn onto a cardboard box.";
@@ -86954,9 +86991,6 @@
 "yib" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
 	},
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/delivery,
@@ -109234,7 +109268,7 @@ aYU
 boj
 bqy
 bsK
-bky
+ieX
 bwh
 buj
 bzI
@@ -109491,7 +109525,7 @@ baG
 bok
 bqz
 bsL
-buk
+cCD
 dCH
 baG
 baG
@@ -110764,7 +110798,7 @@ qfD
 sMN
 sMN
 aXV
-aZa
+cuH
 baK
 jFq
 hXC
@@ -111567,8 +111601,8 @@ bTK
 cuH
 bWn
 ciV
+cay
 bXL
-cah
 cbS
 cdw
 czE
@@ -111823,7 +111857,7 @@ jmy
 bTL
 aYX
 bWj
-bXX
+bZa
 clV
 cai
 cbT
@@ -112084,7 +112118,7 @@ bXN
 bZb
 cca
 cbU
-cdz
+ceK
 ceE
 cfU
 cha
@@ -113111,7 +113145,7 @@ caT
 ckk
 cdw
 can
-vLX
+cca
 dDo
 ceJ
 cfY
@@ -113627,7 +113661,7 @@ bZa
 cap
 cca
 cdE
-ceK
+ceJ
 cfX
 chf
 ciA
@@ -113650,7 +113684,7 @@ cAg
 ctB
 cCe
 cCe
-ydu
+cCe
 cEY
 cCe
 cCe
@@ -114162,8 +114196,8 @@ cyn
 czf
 cAh
 cBe
-chg
-chg
+cOJ
+cOJ
 cEg
 cFa
 cFZ
@@ -114171,7 +114205,7 @@ cGU
 cHN
 cIE
 cJE
-cKD
+cKw
 cLs
 cLm
 cMW
@@ -114398,33 +114432,33 @@ bZg
 vVw
 wRE
 cdH
-ceL
+vVw
 uWx
 cnO
 cnO
 cnO
 cnO
-ceL
+vVw
 fdm
 cnO
-ceL
+vVw
 crG
 csK
 qGT
-aPf
-car
-car
+vVw
+vVw
+vVw
 cxA
-car
+vVw
 car
 cAi
-ctF
-car
-car
-czg
+qGT
+vVw
+vVw
+vVw
 cFb
-car
-car
+vVw
+uWx
 cHO
 cIF
 cJF
@@ -114670,18 +114704,18 @@ csL
 spp
 bze
 cvG
-chh
+vFs
 cxB
-cyo
+vFs
 czh
 cAj
-ctG
+spp
 cCm
-cpa
-cEh
+cnP
+cnP
 cFc
-chh
-chh
+vFs
+vFs
 cvG
 cIG
 cJG
@@ -115426,7 +115460,7 @@ bZn
 cau
 ohK
 cdJ
-uRM
+ceL
 cgd
 chj
 cjY
@@ -115451,7 +115485,7 @@ cCo
 cDb
 cEk
 cFd
-cGb
+nUC
 cGb
 cHQ
 cIJ
@@ -115709,7 +115743,7 @@ cDc
 cEl
 cFe
 cGc
-cFg
+cFe
 cHR
 cIK
 cJJ
@@ -115935,9 +115969,9 @@ lJx
 bTT
 oao
 bWB
-bXX
+bZj
 bZl
-ohK
+fKM
 ohK
 cdJ
 coe
@@ -115967,7 +116001,7 @@ lOi
 cFf
 cFg
 cFf
-cHR
+cHS
 cIL
 cJK
 cCq
@@ -116224,7 +116258,7 @@ cEm
 cFg
 cFg
 dDE
-cHR
+cHS
 cIM
 cJL
 cKG
@@ -116451,7 +116485,7 @@ bVm
 bWA
 xDL
 fAn
-cay
+cqP
 cci
 cdL
 cJQ
@@ -116479,8 +116513,8 @@ cCq
 cDf
 lOi
 cFf
-cGd
-cGW
+cFg
+cFf
 cHS
 cIN
 cJM
@@ -116707,7 +116741,7 @@ bTW
 qSJ
 wlF
 bXY
-bZm
+caA
 ohK
 nCa
 cdM
@@ -116741,8 +116775,8 @@ cGX
 cHT
 cFh
 cFh
-cKH
-cLy
+cCq
+cxL
 wFH
 bqv
 rwh
@@ -116963,10 +116997,10 @@ lJx
 bTX
 ecA
 bWB
-bXX
+bZj
 erw
-caA
 ohK
+fQZ
 cdN
 ceT
 cgh
@@ -117241,9 +117275,9 @@ clK
 ctL
 vAQ
 cvL
+vAQ
 cvL
-ctL
-cvL
+cBm
 cAs
 cBm
 cCq
@@ -117257,7 +117291,7 @@ cIP
 cCq
 cCq
 cLA
-bTs
+qDt
 bTs
 bTs
 aaf
@@ -117492,38 +117526,38 @@ cgo
 cyx
 cpl
 cqE
-crM
+cqE
 csV
 ctN
 cuI
 ohK
+jgc
 ohK
-sUc
 cyv
 czo
 cAt
-cBn
+cIQ
 cCr
-cDj
+ohK
 caw
-cFk
+ohK
 cGg
 cHa
 cHW
-cIQ
+oVa
 cJO
-cKI
+cgo
 cQr
 cQR
+cRb
 cRa
-cSd
+cRi
 cRe
 cRe
 cRe
 cRe
-cRe
-cRe
-lMJ
+cRi
+cRi
 bBj
 lMJ
 aaa
@@ -117757,13 +117791,13 @@ cvN
 hut
 fLC
 cyw
-czp
+rvm
 cAu
-cBo
+fLC
 crL
-cwN
+fLC
 dDy
-cFl
+fLC
 cGh
 cHb
 cHX
@@ -117774,13 +117808,13 @@ cQt
 cQZ
 cRc
 cRf
+rcL
 cYT
-cRg
+rms
 cYT
 cYT
-djg
-cRe
-aaa
+saT
+cRi
 lMJ
 aaa
 aaa
@@ -118003,24 +118037,24 @@ aAk
 rTl
 abN
 rIw
-ohK
+hbh
 cpn
 cqE
 crM
 csX
-ohK
+iMF
 cuK
 cvO
-cwO
+cEp
 cxJ
 cCs
-czq
+cCs
 cAv
 cCs
-cCs
+ltg
 ctP
 cEp
-cFm
+ohK
 cGi
 cHc
 cHY
@@ -118030,14 +118064,14 @@ cgo
 cQs
 cQS
 cRb
+cRa
+cRi
 cRe
-cRe
-cRe
-cRe
-cRe
+cRi
+cRi
+rSL
 cZa
 cRe
-aaa
 aaa
 aaa
 aaa
@@ -118260,7 +118294,7 @@ gTs
 cki
 ijI
 rIw
-ohK
+hbh
 cpu
 cqH
 rrX
@@ -118271,7 +118305,7 @@ lja
 rrX
 omw
 sJE
-czr
+sJE
 cAw
 cBq
 xuf
@@ -118285,18 +118319,18 @@ cIT
 cIT
 cIg
 dAw
+qDJ
 dvY
 dvY
-aaa
 aaf
 aaa
 aaa
-cRe
+cRi
+cRi
 cZa
 cRe
-aaa
-aaa
-aaa
+lMJ
+lMJ
 aaf
 aaa
 aaa
@@ -118517,9 +118551,9 @@ cJa
 fFM
 mWb
 rIw
-ohK
+hbh
 cpu
-ohK
+dXa
 jiG
 kmT
 eTY
@@ -118548,10 +118582,10 @@ aaa
 aaf
 aaa
 aaa
+aaa
+cRi
+shE
 cRe
-cZa
-cRe
-aaf
 aaa
 aaa
 aaf
@@ -118776,7 +118810,7 @@ cgo
 cgo
 xkG
 cpq
-ohK
+dXa
 vXa
 amA
 dvg
@@ -118805,9 +118839,9 @@ aaf
 aaf
 aaf
 aaa
+aaa
 cRe
 cZa
-cRe
 cRu
 cRi
 cRi
@@ -119000,7 +119034,7 @@ bmJ
 boJ
 bra
 btj
-buL
+cDj
 hIO
 byv
 bcl
@@ -119062,9 +119096,9 @@ aaa
 aaa
 aaf
 aaf
+aaa
 cRe
-cZa
-cRe
+shK
 cRi
 dbX
 dcg
@@ -119247,7 +119281,7 @@ aWq
 aXY
 aZr
 bba
-buk
+bdP
 baG
 baG
 bhB
@@ -119290,7 +119324,7 @@ obb
 jIy
 ubH
 bna
-ohK
+hfU
 rrX
 vGw
 qEi
@@ -119319,9 +119353,9 @@ dvY
 dvY
 dvY
 dvY
+lMJ
 cRe
-djh
-cYT
+sCL
 cRv
 dbY
 dch
@@ -119505,7 +119539,7 @@ aXZ
 aZs
 bbb
 bcm
-bdQ
+bfF
 bfF
 bhC
 bjn
@@ -119541,7 +119575,7 @@ bSS
 csg
 cgo
 chs
-dlt
+iAD
 ckm
 clN
 jIy
@@ -119564,7 +119598,7 @@ cyK
 cEu
 cFo
 cEu
-cHe
+odq
 cIe
 cIY
 cIe
@@ -119576,8 +119610,8 @@ cgs
 cOB
 cPf
 dvY
-cRe
-cRe
+aaa
+cRi
 cRe
 cRi
 dbZ
@@ -119814,8 +119848,8 @@ wEJ
 rrX
 cyE
 czx
-cAB
-cBw
+dDA
+cCx
 cCx
 cDk
 cEv
@@ -120070,16 +120104,16 @@ crR
 crR
 crR
 cyF
-czy
+jor
 cAC
-cCA
+ktV
 cCy
 cDl
 cEu
 cFq
 cEu
-cHe
-cIg
+oJt
+oOQ
 cIg
 cIg
 cIg
@@ -120090,8 +120124,8 @@ ciL
 ciL
 cPh
 dvY
-aaa
-aaa
+lMJ
+lMJ
 aaf
 cRi
 cRh
@@ -120329,13 +120363,13 @@ crR
 cyG
 czz
 cAD
-cCA
-cCA
+kHk
+kHk
 cDm
 cEw
-cFr
+kHk
 cGl
-cHg
+cHi
 cIh
 dAh
 dbl
@@ -120344,7 +120378,7 @@ cLF
 dvY
 dvY
 cNW
-cOC
+cra
 dvY
 dvY
 aaa
@@ -120549,7 +120583,7 @@ nFG
 mvj
 wpo
 emB
-mDX
+bYd
 mHB
 kgv
 lao
@@ -120584,23 +120618,23 @@ cuT
 cwW
 crR
 cyH
-czx
+joE
 cAE
-cBz
-cCA
-cDn
+cHi
+cHi
+cHi
 cEx
-cDn
+msu
 cGm
 cHh
 cIi
 dAp
-dAp
+qnH
 cKK
 cxM
 dvY
 cNl
-dAZ
+cma
 cOD
 cPi
 dvY
@@ -120805,9 +120839,9 @@ mte
 pSX
 mvj
 wpo
-bYa
+upO
 bYd
-chy
+mHB
 dYw
 lao
 kBH
@@ -120843,15 +120877,15 @@ cxK
 cyI
 czA
 cAF
-cBA
-cCB
-cDo
+cHi
+cHi
+cHi
 cEy
-cFs
+cHi
 cGn
 cHi
-cIj
-dvY
+cyK
+pcs
 dvY
 cKL
 dvY
@@ -121061,10 +121095,10 @@ vBv
 mvj
 eXX
 qWu
-tlF
+cdS
 upO
-mDX
-mjp
+bYd
+mHB
 usd
 kAx
 lao
@@ -121100,21 +121134,21 @@ crR
 cyJ
 xro
 mxR
-cBB
+fco
 fco
 cDp
 czB
 cAG
 cEz
+cHi
 cyK
 cLF
 dvY
-cJY
 cKM
 cLH
 dvY
 cNn
-dAZ
+cma
 cOE
 cPh
 dvY
@@ -121317,11 +121351,11 @@ wep
 xKw
 sZJ
 sZJ
-pIJ
-tlF
+cdS
+cdS
 iuF
 lYI
-mjp
+mHB
 til
 unK
 pTI
@@ -121354,18 +121388,18 @@ cuW
 cvY
 fRJ
 crR
-gCe
-cyK
+jgy
+jyo
 cAH
+kLP
+lUs
+lXt
+mhG
+nAB
+oag
 cyK
 cyK
-cyK
-gCe
-cyK
-cyK
-cyK
-diP
-dvY
+pse
 cJZ
 cKN
 diU
@@ -121611,19 +121645,19 @@ dwL
 dwL
 dwL
 dwL
-xAp
-vhG
+gCe
+cyK
 cAI
-cBD
-cCD
-uun
-rSL
-dwL
-dyc
-gGH
-pVL
+cyK
+cyK
+cyK
+gCe
+cyK
+cyK
+cyK
+jLY
+dxQ
 dvY
-cKa
 cKO
 cLJ
 cor
@@ -121829,12 +121863,12 @@ apc
 xLe
 wep
 iaE
-pIJ
+ccU
 wpE
-pIJ
-tlF
+bXX
+cdS
 pRp
-mDX
+bYd
 eBu
 vWO
 xYE
@@ -121871,27 +121905,27 @@ gHh
 wRy
 veB
 mtn
-mEk
+kWW
 mEk
 cCE
-oVa
+mEk
 czC
 dzI
 cIl
 dAd
+pIJ
 dvY
 dvY
 dvY
-dvY
 cKP
 cKP
 cKP
 cKP
 cKP
-aaa
-aaa
-aaa
-aaa
+ryl
+ryl
+saP
+ryl
 cRi
 dcd
 dcq
@@ -122077,7 +122111,7 @@ dnh
 dnh
 dnh
 dnh
-psM
+chh
 bjC
 dCM
 alq
@@ -122089,10 +122123,10 @@ dpF
 ccU
 pXC
 rzT
-tlF
+cdS
 gin
 ocV
-hzY
+ocV
 rTV
 reC
 les
@@ -122136,7 +122170,7 @@ dwL
 dww
 gEk
 eZe
-dAp
+pVL
 cPx
 cJb
 cKb
@@ -122348,7 +122382,7 @@ vqd
 wep
 vqd
 uds
-jGA
+cKa
 vqd
 vWO
 vWO
@@ -122384,9 +122418,9 @@ cuZ
 cuZ
 cuZ
 ioI
-cuZ
+kdi
 czD
-cyy
+czD
 cBG
 czD
 cyK
@@ -122641,8 +122675,8 @@ lal
 ygk
 sdi
 fDD
-wKo
-czD
+cuZ
+kXS
 cQC
 cBH
 cCG
@@ -122660,7 +122694,7 @@ cMs
 cNq
 cKP
 aaa
-aac
+ake
 aaa
 aaa
 cRi
@@ -122862,8 +122896,8 @@ pYn
 uzY
 syK
 nCW
-syK
 uzY
+syK
 xSU
 vWO
 wni
@@ -123105,9 +123139,9 @@ tMD
 whB
 tMD
 tMD
-bhL
-bjv
-bla
+psM
+bjC
+bmV
 wep
 bts
 abt
@@ -123178,7 +123212,7 @@ aaa
 aaf
 aaa
 aaa
-vLD
+lMJ
 aaa
 aaf
 aaa
@@ -123376,8 +123410,8 @@ kCR
 uzY
 lPE
 nCW
-nGs
 uzY
+cah
 ckd
 vWO
 lIk
@@ -124134,8 +124168,8 @@ vNm
 wiv
 smU
 dCJ
-bjC
-bmV
+cpa
+cyo
 alq
 anM
 brs
@@ -124457,7 +124491,7 @@ aaa
 aaa
 pDz
 aaa
-aaa
+lyC
 aaf
 aaa
 aaa
@@ -125939,7 +125973,7 @@ bmV
 bpd
 cPs
 btx
-buZ
+bmV
 bwZ
 byP
 bAx
@@ -126214,8 +126248,8 @@ bNO
 bTf
 alq
 diu
-bWZ
-bYs
+woc
+dDs
 bZB
 bZE
 ccG
@@ -126717,8 +126751,8 @@ ieJ
 nGn
 uoM
 lUn
-dlF
-uhB
+qxd
+qxd
 qxd
 qtO
 qtO
@@ -126962,7 +126996,7 @@ ixs
 gzG
 seS
 uJR
-rcL
+tMN
 pjR
 pTr
 oIN
@@ -126975,7 +127009,7 @@ tQs
 lCf
 dVc
 hQl
-qnH
+oHW
 oHW
 atm
 bLX
@@ -126984,7 +127018,7 @@ bQQ
 bSe
 bTh
 bUx
-aut
+bSe
 bXc
 bZz
 bZE
@@ -127197,7 +127231,7 @@ ocS
 eDX
 mJR
 xKG
-kHk
+mJR
 eDX
 eDX
 pAO
@@ -127221,7 +127255,7 @@ hKU
 kiW
 gyR
 jtI
-cLz
+pTr
 gdJ
 iLe
 bve
@@ -127231,17 +127265,17 @@ jje
 woN
 jAn
 tyC
-kLr
-rms
+mMn
+plN
 plN
 atm
 bLY
-bPl
+uVG
 apc
 aqq
-apc
+dlt
 bUy
-bPs
+alq
 bXd
 apf
 bZE
@@ -127452,9 +127486,9 @@ ihO
 ocS
 vgI
 mNV
-ryl
+urs
 dpm
-kLP
+urs
 qZf
 szK
 urs
@@ -127475,8 +127509,8 @@ nmz
 nmz
 nmz
 vsF
-kiW
 tMN
+cyy
 mmy
 pTr
 qCB
@@ -127485,20 +127519,20 @@ bCK
 qxd
 jJw
 usM
-lXt
-mhG
+woN
+lzQ
 tyC
-kLr
-kdi
+mMn
+gmD
 gmD
 atm
-bLZ
+apc
 bPm
-apc
+chE
 bSf
-apc
+dsL
 qxd
-uhB
+qxd
 bXe
 qxd
 qxd
@@ -127709,12 +127743,12 @@ aAm
 ocS
 ylE
 eOd
-mFr
-tHP
+sLW
+vSv
 sLW
 lUC
-lUC
-lUC
+sLW
+sLW
 ezu
 xbT
 opc
@@ -127722,9 +127756,9 @@ xLR
 wAX
 nnB
 vSv
-saT
+vZm
 kwP
-dsL
+eDX
 scD
 vfZ
 lrV
@@ -127732,21 +127766,21 @@ dtM
 eDX
 lLt
 fJU
-kiW
+tMN
 tMN
 nYq
-pTr
+czq
 eDP
 iLe
 bvg
-odq
+qxd
 ipm
 oBF
 vjV
 pCS
 jxI
-kLr
-qDJ
+mMn
+mmU
 mmU
 atm
 cTw
@@ -127964,7 +127998,7 @@ avt
 awJ
 axS
 ocS
-lmt
+bky
 vGP
 vrr
 gjr
@@ -127974,23 +128008,23 @@ ePL
 ePL
 ePL
 dZP
-ePL
+bLZ
 dxr
-ePL
+bPl
 dur
 khP
 ksV
 wcY
 qJb
-pLx
+skz
 lod
 jSx
-heu
+skz
 iTy
 xPz
 vZw
 iMH
-cmO
+iMH
 cqJ
 kxY
 kNr
@@ -128000,10 +128034,10 @@ qxd
 oNX
 vzb
 iix
-woN
-tyC
-kLr
-iix
+cGd
+cJY
+qVE
+mMn
 sKv
 qxd
 qxd
@@ -128014,7 +128048,7 @@ qxd
 qxd
 cZH
 hpw
-tfk
+mMn
 mMn
 faG
 sKe
@@ -128226,7 +128260,7 @@ jUF
 kSn
 qAr
 pAk
-tiT
+pAk
 kjA
 eOf
 pAk
@@ -128234,7 +128268,7 @@ kjR
 pAk
 nVX
 oCb
-tiT
+pAk
 pAk
 aAs
 wZn
@@ -128246,10 +128280,10 @@ eWn
 eDX
 lLt
 qGP
-kiW
+tMN
 lKe
 qlI
-lKe
+cBn
 vCf
 iLe
 kqF
@@ -128257,11 +128291,11 @@ qxd
 wtG
 qWR
 cVp
-woN
+cGW
 dtk
 lFH
 hdJ
-shK
+sKv
 itH
 itH
 mgn
@@ -128478,7 +128512,7 @@ avv
 ocS
 rTM
 gtO
-ygd
+bla
 pan
 vdd
 eNK
@@ -128494,7 +128528,7 @@ ptX
 tZi
 wtK
 eNK
-mzH
+sKz
 ocS
 aYu
 aYu
@@ -128503,26 +128537,26 @@ aYu
 aYu
 aYu
 yeW
-kiW
+tMN
 lKe
 qnE
 lKe
-nUC
+tMN
 iLe
 iLe
 qxd
 oBX
 olw
-pse
+sKv
 izT
+sKv
 uKL
-ktV
-wKg
-uTg
+uKL
+sKv
 tFA
 hHh
 jxw
-jxw
+cOC
 jDD
 xGN
 xGN
@@ -128728,11 +128762,11 @@ kCp
 kCp
 kCp
 kCp
-dLm
-jgc
+kCp
+kCp
 iFm
 mEE
-jgc
+kCp
 fuH
 nid
 sYL
@@ -128751,7 +128785,7 @@ dOw
 dOw
 mZT
 fDh
-mzH
+sKz
 apc
 aYu
 aZL
@@ -128759,18 +128793,18 @@ bbB
 pdm
 bem
 bfV
-oag
-vmm
+qGP
+tMN
 olW
 sah
-xov
-ltg
+tMN
+tMN
 txb
 trn
 sKv
 oay
 fNf
-kWW
+sKv
 vXi
 grX
 hop
@@ -128778,18 +128812,18 @@ ldI
 elC
 kKa
 ooB
-ibJ
-ibJ
-ibJ
-ibJ
-ibJ
-ibJ
+ooB
+cRg
+diP
+bvN
+bvN
+bvN
 omb
 mMn
 mMn
 iAK
 tie
-kTS
+vxg
 cfw
 mTL
 ilE
@@ -128981,7 +129015,7 @@ aaf
 kCp
 khq
 uPN
-kXS
+khq
 qpQ
 xvg
 hBG
@@ -129019,7 +129053,7 @@ bfW
 paS
 nmt
 hNW
-hNW
+czg
 xNe
 eDc
 lTr
@@ -129028,25 +129062,25 @@ hZe
 mZD
 mSB
 dRb
-oBF
+cIj
 tFH
-tfk
+cKD
 sfM
 kBk
-mMn
 eCZ
-mMn
-mMn
-mMn
-mMn
-mMn
-mMn
-eWY
+eCZ
+eCZ
+eCZ
+djg
+eCZ
+eCZ
+eCZ
+dAZ
 mMn
 veT
 lvk
 xuP
-rid
+vxg
 cfx
 dPI
 dPI
@@ -129238,7 +129272,7 @@ aag
 kCp
 trj
 qGt
-nAB
+jSy
 mNX
 xXs
 pHX
@@ -129249,9 +129283,9 @@ nPJ
 kCp
 qCO
 dKV
-sCL
+pAk
 qIM
-qDt
+tZi
 ipw
 iBm
 hab
@@ -129265,7 +129299,7 @@ uIA
 pIc
 dTj
 eYH
-mzH
+sKz
 apc
 aYu
 aZN
@@ -129280,21 +129314,21 @@ ryM
 kNM
 vpQ
 kuk
-oOQ
+trn
 naf
 gaV
 fpg
-lUs
+sKv
 fFR
 fNh
 tNF
-dHR
+mMn
 nwU
 lOv
-pcs
-mMn
-mMn
-mMn
+bvN
+bvN
+bvN
+djh
 mMn
 mMn
 mMn
@@ -129496,7 +129530,7 @@ kCp
 jMw
 khq
 ekH
-khq
+aPf
 msv
 fUl
 btW
@@ -129506,9 +129540,9 @@ avz
 ocS
 ocS
 uuf
-mlA
-fQZ
-fKM
+ocS
+ghb
+ocS
 xtF
 iBm
 hXs
@@ -129537,12 +129571,12 @@ iYP
 eZS
 iYP
 iYP
-jgy
+iYP
 uhB
 jiZ
+cFm
 mHn
 mHn
-fGc
 rdg
 fGc
 lHN
@@ -129752,7 +129786,7 @@ aaf
 kCp
 jSy
 qGt
-oJt
+trj
 mgJ
 uTn
 mpO
@@ -129779,7 +129813,7 @@ rkx
 dZC
 jVR
 eYH
-mzH
+sKz
 aWH
 dgi
 dgc
@@ -129801,7 +129835,7 @@ nJr
 oVH
 xnt
 kyJ
-dHX
+uED
 vRu
 kJQ
 wqG
@@ -130016,14 +130050,14 @@ uot
 htH
 hGo
 kCp
-dpG
+bdQ
 ocS
 hzd
-stG
+bjv
 vPE
 roz
-iMF
-jyo
+tZi
+ipw
 qkC
 jfY
 rSx
@@ -130054,10 +130088,10 @@ wBE
 fHh
 flE
 rMA
-npE
+nJr
 pPS
 esR
-mMn
+hfg
 uED
 hfg
 tac
@@ -130273,14 +130307,14 @@ kCp
 kCp
 kCp
 kCp
-dpG
+bdQ
 ocS
 lPI
-stG
+bjR
 pwE
 iuW
 kBn
-ipw
+bzp
 qkC
 kCX
 rSx
@@ -130293,7 +130327,7 @@ rSx
 okX
 lJc
 gPs
-mzH
+bWZ
 atm
 alr
 dgp
@@ -130331,7 +130365,7 @@ mMn
 tSa
 fqD
 jwC
-ktI
+vxg
 cfy
 wJb
 vHq
@@ -130530,13 +130564,13 @@ aaf
 dni
 dps
 dpL
-dpG
+bdQ
 ocS
 hzd
-stG
+bjR
 tkS
 iuW
-kBn
+brZ
 ipw
 hdk
 jfY
@@ -130564,7 +130598,7 @@ iYP
 sCD
 wOW
 xdX
-hbh
+iYP
 dFX
 dlF
 fCZ
@@ -130572,11 +130606,11 @@ qVE
 qoD
 oyV
 mtM
-ixJ
+sGo
 htZ
 oLm
 eWY
-kEE
+cKI
 mMn
 mMn
 mMn
@@ -130787,13 +130821,13 @@ apm
 apm
 apm
 dnR
-dpG
+bdQ
 ocS
 hVj
 iXR
 xti
-stG
-eHP
+bnz
+btM
 hij
 gLc
 dZC
@@ -130823,14 +130857,14 @@ brM
 aNC
 iYP
 iod
-joE
+qxd
 lYe
 tfk
 vms
 vOz
 wAs
 qha
-jor
+kdB
 xaR
 htZ
 kEE
@@ -130841,8 +130875,8 @@ mMn
 mMn
 mMn
 mMn
-mMn
-xxf
+dHR
+xaR
 mze
 rlJ
 vxg
@@ -131047,9 +131081,9 @@ dnS
 avB
 ocS
 ocS
-mlA
-hfU
-fQZ
+ocS
+ocS
+tZi
 nFz
 eXd
 uLv
@@ -131086,7 +131120,7 @@ okm
 wMJ
 lOJ
 fVg
-cZV
+sGo
 jfa
 hTE
 hpr
@@ -131098,11 +131132,11 @@ snq
 hPo
 odn
 iyn
-snq
+dLm
 veq
 ugm
-rSI
-xqi
+gGH
+qxd
 aaf
 dPI
 dPI
@@ -131301,7 +131335,7 @@ aqz
 arU
 atk
 aux
-avF
+bhL
 dqT
 dqT
 aaf
@@ -131333,7 +131367,7 @@ cUL
 aaa
 aaf
 aaf
-bpw
+bpy
 aaa
 aaf
 aaf
@@ -131359,7 +131393,7 @@ jfi
 wFu
 wFu
 pjr
-xqi
+qxd
 aaf
 aaf
 aaf
@@ -131564,7 +131598,7 @@ dqT
 aaf
 ack
 ack
-iET
+nFz
 tZi
 wQo
 tZi
@@ -131578,7 +131612,7 @@ ocS
 tZi
 wQo
 tZi
-mzH
+sKz
 dgf
 dgk
 dgt
@@ -131590,7 +131624,7 @@ aaf
 aaf
 aaf
 aaa
-bpw
+bpy
 aaa
 aaa
 aaf
@@ -131603,20 +131637,20 @@ thi
 ktI
 eBq
 ktI
-thi
+cKH
 xqW
 eBq
 ktI
-thi
+cKH
 ktI
 eBq
 ktI
-thi
+cKH
 fhB
 fhB
 fhB
 gBn
-usC
+qxd
 aaf
 aaa
 aaa
@@ -131821,7 +131855,7 @@ dqT
 aaf
 aaf
 aaf
-iET
+nFz
 axL
 tJj
 bWx
@@ -131835,7 +131869,7 @@ axL
 bWx
 tJj
 nWG
-mzH
+sKz
 aWK
 dgk
 dgt
@@ -132078,7 +132112,7 @@ dqT
 aaa
 aaa
 aaa
-mlA
+nFz
 taH
 mKw
 jng
@@ -132092,7 +132126,7 @@ axL
 omQ
 uYg
 hJe
-hvd
+sKz
 dgg
 azd
 azd
@@ -132104,7 +132138,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpy
 aaf
 aaf
 aaf
@@ -132335,7 +132369,7 @@ aaa
 aaa
 aaa
 aaa
-ocS
+buZ
 vvU
 mKw
 lRl
@@ -132349,7 +132383,7 @@ axL
 usB
 uYg
 lcm
-ocS
+bYs
 aWK
 dgk
 dgt
@@ -132361,7 +132395,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaa
 aaf
@@ -132618,7 +132652,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaa
 aaf
@@ -132875,7 +132909,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpy
 aaf
 aaf
 aaf
@@ -133132,7 +133166,7 @@ aaf
 aaf
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -133389,7 +133423,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaf
@@ -133646,7 +133680,7 @@ btu
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -133903,7 +133937,7 @@ btu
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaf
@@ -134160,7 +134194,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -134417,7 +134451,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaf
@@ -134674,7 +134708,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpy
 aaf
 aaf
 aaa
@@ -134931,7 +134965,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaf
@@ -135188,7 +135222,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -135445,7 +135479,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -135702,7 +135736,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -135959,7 +135993,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -136216,7 +136250,7 @@ aaa
 aaa
 aaf
 aaa
-bpw
+bpy
 aaa
 aaf
 aaa
@@ -136473,7 +136507,7 @@ aaa
 aaa
 aaf
 aaf
-bpx
+bpy
 aaf
 aaf
 aaa
@@ -136987,7 +137021,7 @@ aaa
 aaa
 aaf
 aaa
-bpy
+cBD
 aaa
 aaf
 aaa
@@ -139556,7 +139590,7 @@ aVk
 aOY
 aOY
 aSG
-shE
+jYV
 xRM
 tdS
 aOU
@@ -140070,9 +140104,9 @@ aaa
 aaa
 xVW
 xVW
-xDY
+xVW
 bpI
-saP
+xVW
 xVW
 aaa
 aaa
@@ -140589,7 +140623,7 @@ oKi
 bsf
 bGh
 nix
-bGh
+cEh
 xVW
 xVW
 xVW
@@ -141098,12 +141132,12 @@ bgh
 bim
 bjQ
 bjQ
-bnz
+bjQ
 bpM
-brZ
+bjQ
 btL
 bvu
-bxq
+bxo
 bzn
 bAU
 bCD
@@ -141350,10 +141384,10 @@ bJj
 aZS
 bJj
 bJj
-bJj
+chg
 bgi
 bin
-bjR
+bjQ
 brX
 bnA
 bpN
@@ -141610,15 +141644,15 @@ aTV
 beu
 bPf
 bio
-bjR
+bjQ
 blF
 bnB
 bpO
 bsb
-btM
+btL
 bvw
 bxo
-bzp
+bxq
 bxq
 bCE
 bCE
@@ -141856,7 +141890,7 @@ qaA
 slh
 slh
 xMk
-msu
+xVW
 aTW
 bjS
 aWO
@@ -141885,7 +141919,7 @@ bKM
 bKO
 bMp
 bNZ
-xMk
+rgc
 pbQ
 slh
 nAl
@@ -142112,7 +142146,7 @@ sBz
 uvH
 aOV
 aaa
-xVW
+bPs
 rgc
 aTX
 aVp
@@ -142131,7 +142165,7 @@ bpQ
 bsd
 btL
 bvy
-bxq
+bxo
 bzr
 bAY
 bCE
@@ -142388,7 +142422,7 @@ bpR
 byM
 btL
 bxq
-bxq
+cFk
 bzs
 bJi
 bCD
@@ -142640,13 +142674,13 @@ bgm
 bis
 bjQ
 bjQ
-bnz
+bjQ
 bpS
-brZ
+bjQ
 btL
 bvA
 bxs
-bxq
+bzs
 bBa
 bCD
 bEg


### PR DESCRIPTION
## About The Pull Request

This time I prioritized the atmospherics pipes concerning engineering, the AI SAT, the rest of science, and some of the southern halls. As well as touching up some, but not all, areas of science including Toxins/Ordinance. I aim to touch the main R&D lab, the RD's office, and robotics in a future patch.

## Why It's Good For The Game

GATO NUMBA NUMBA 1 SUIIIIII!!!!!

## Changelog
:cl:
add: New space to Toxins/Ordinance
del: Something idrk
tweak: Some stuff was touched regarding previous designs made in aims to find a focal point for the looks I was going for.
balance: pencil on my nose
fix: Some errors regarding previous mappers' changes, including: leftovers that were not removed and pipes that were made but not connected.
admin: Lew's big and round belly
qol: AI SAT, Atmospherics, and the rest of Science's supply/scrubber pipes. Reinforced xenobio's glass tunnel and moved a carp spawn a little further down to prevent regular breaking per shift.
/:cl:
