### PR TITLE
Toggle others' giant sprite Functions

### DIFF
--- a/GainStation13/code/modules/mob/living/species.dm
+++ b/GainStation13/code/modules/mob/living/species.dm
@@ -271,13 +271,7 @@
 	fatness_delay = min(fatness_delay, delay_cap)
 	return fatness_delay
 
-/datum/species/proc/grant_resize_others(mob/living/carbon/human/H)
-	if(!H.resize_others)
-		H.resize_others = new(src)
-		H.resize_others.Grant(H)
-
 /datum/species/proc/handle_fatness(mob/living/carbon/human/H)
-	grant_resize_others(H)
 	handle_helplessness(H)
 	H.handle_modular_items()
 

--- a/GainStation13/code/modules/mob/living/species.dm
+++ b/GainStation13/code/modules/mob/living/species.dm
@@ -271,7 +271,13 @@
 	fatness_delay = min(fatness_delay, delay_cap)
 	return fatness_delay
 
+/datum/species/proc/grant_resize_others(mob/living/carbon/human/H)
+	if(!H.resize_others)
+		H.resize_others = new(src)
+		H.resize_others.Grant(H)
+
 /datum/species/proc/handle_fatness(mob/living/carbon/human/H)
+	grant_resize_others(H)
 	handle_helplessness(H)
 	H.handle_modular_items()
 

--- a/GainStation13/code/modules/resize/height_limits.dm
+++ b/GainStation13/code/modules/resize/height_limits.dm
@@ -2,31 +2,6 @@
 	var/datum/action/resize_others/resize_others
 	var/see_resized_others = FALSE
 
-/datum/action/resize_others
-	name = "Toggle Others' Giant Sprites"
-	desc = "Others will now look small to you."
-	icon_icon = 'icons/mob/screen_gen_old.dmi'
-	button_icon_state = "health1"		//You can change this if you want
-	background_icon_state = "bg_alien"	//But keep this as a distinct background
-
-/datum/action/resize_others/Trigger()
-	..()
-	owner.see_resized_others = !owner.see_resized_others
-	if(owner.see_resized_others)
-		for(var/mob/living/L in GLOB.mob_living_list)
-			if(L.size_multiplier > 1)
-				L.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/showSmall, "gscode_smallsprite", GenerateSprite(L), FALSE)
-				var/datum/atom_hud/alternate_appearance/AA = L.alternate_appearances["gscode_smallsprite"]
-				if(L != owner)
-					AA.add_to_single_hud(owner, L)
-	else
-		for(var/mob/living/L in GLOB.mob_living_list)
-			if(L.size_multiplier > 1)
-				var/datum/atom_hud/alternate_appearance/AA = L.alternate_appearances["gscode_smallsprite"]
-				if(AA)
-					AA.remove_from_single_hud(owner, L)
-	return TRUE
-
 /datum/action/resize_others/proc/GenerateSprite(mob/living/L)
 	var/image/I = image(icon=L.icon,icon_state=L.icon_state,loc=L,layer=L.layer,pixel_x=L.pixel_x,pixel_y=L.pixel_y)
 	I.overlays += L.overlays
@@ -43,3 +18,35 @@
 
 /datum/atom_hud/alternate_appearance/basic/showSmall/mobShouldSee(mob/M)
 	return FALSE
+
+/client/verb/toggle_others_giant()
+	set name = "Toggle Others' Giant Sprite"
+	set category = "Preferences"
+	set desc = "Change display settings to and from displaying others' giant sprites."
+	message_admins("Working")
+	mob.see_resized_others = !mob.see_resized_others
+	if(mob.see_resized_others)
+		for(var/mob/living/L in GLOB.mob_living_list)
+			if(L && L.size_multiplier > 1)
+				L.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/showSmall, "gscode_smallsprite", GenerateSprite(L), FALSE)
+				var/datum/atom_hud/alternate_appearance/AA = L.alternate_appearances["gscode_smallsprite"]
+				if(L != mob)
+					message_admins(mob.name)
+					AA.add_to_single_hud(mob, L)
+					message_admins("Done")
+	else
+		for(var/mob/living/L in GLOB.mob_living_list)
+			if(L && L.size_multiplier > 1 && L.alternate_appearances)
+				message_admins(L.name)
+				var/datum/atom_hud/alternate_appearance/AA = L.alternate_appearances["gscode_smallsprite"]
+				if(AA)
+					AA.remove_from_single_hud(mob, L)
+					message_admins("Removed")
+
+/client/proc/GenerateSprite(mob/living/L)
+	if(!L)
+		return
+	var/image/I = image(icon=L.icon,icon_state=L.icon_state,loc=L,layer=L.layer,pixel_x=L.pixel_x,pixel_y=L.pixel_y)
+	I.overlays += L.overlays
+	I.override = TRUE
+	return I

--- a/GainStation13/code/modules/resize/height_limits.dm
+++ b/GainStation13/code/modules/resize/height_limits.dm
@@ -63,8 +63,7 @@ GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 			GLOB.enabled_smallsprite -= src
 		return FALSE
 
-//Generate the image based on the mob's current icon and apply matrix transformations
-// to adjust its position and angle
+///Generate the image based on the mob's current icon and apply matrix transformations to adjust its position and angle
 /mob/living/proc/generate_smallsprite()
 	var/image/I = image(icon=icon, icon_state=icon_state, loc=src, layer=layer, pixel_x=pixel_x, pixel_y=pixel_y)
 	I.overlays += overlays

--- a/GainStation13/code/modules/resize/height_limits.dm
+++ b/GainStation13/code/modules/resize/height_limits.dm
@@ -1,20 +1,20 @@
+
+//Lists to keep track of:
+// - Mobs with a sprite size over 100%
+// - Mobs with the toggle activated
+// Done to reduce the amount of mobs that need to be taken into account when the toggle is switched and for updating the seen sprite
 GLOBAL_LIST_EMPTY(enabled_smallsprite)
 GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 
+//var to know if one has the toggle activated or not
 /mob/
 	var/see_resized_others = FALSE
 
 /datum/atom_hud/alternate_appearance/basic/showSmall
 
-/datum/atom_hud/alternate_appearance/basic/showSmall/New()
-	..()
-	for(var/mob in GLOB.player_list)
-		if(mobShouldSee(mob))
-			add_hud_to(mob)
-
-/datum/atom_hud/alternate_appearance/basic/showSmall/mobShouldSee(mob/M)
-	return FALSE
-
+//Verb for the associated toggle.
+//When switched on, add the current mob to the list of mobs that need to see smallsprites and apply the ones already present immediately to the mob's hud.
+//When switched off, remove from the list and remove smallsprites for the user's hud.
 /client/verb/toggle_others_giant()
 	set name = "Toggle Others' Giant Sprite"
 	set category = "Preferences"
@@ -26,6 +26,7 @@ GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 			if(L && L != mob && L.alternate_appearances && L.alternate_appearances["gscode_smallsprite"])
 				var/datum/atom_hud/alternate_appearance/AA = L.alternate_appearances["gscode_smallsprite"]
 				AA.add_to_single_hud(mob, L)
+		to_chat(src, "Resize others view toggled ON.")
 	else
 		mob.see_resized_others = !mob.see_resized_others
 		GLOB.see_toggle_smallsprite -= mob
@@ -33,7 +34,13 @@ GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 			if(L && L.alternate_appearances && L.alternate_appearances["gscode_smallsprite"])
 				var/datum/atom_hud/alternate_appearance/AA = L.alternate_appearances["gscode_smallsprite"]
 				AA.remove_from_single_hud(mob, L)
+		to_chat(src, "Resize others view toggled OFF.")
 
+//Call to regenerate the sprites and update huds.
+//If present, remove the old sprite from the huds and from the mob
+//If the size_multiplier is still higher than 1, check if the mob is in the list of smallsprite mobs and add it if not
+// add a new sprite by generating it, then go through the list of mobs with smallsprites toggled on and it to their hud
+//If the size_multiplier was not higher than one then remove the mob from the list of smallsprite mobs
 /mob/living/proc/regenerate_smallsprite()
 	if(alternate_appearances && alternate_appearances["gscode_smallsprite"])
 		for(var/mob/M in GLOB.see_toggle_smallsprite)
@@ -54,6 +61,8 @@ GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 			GLOB.enabled_smallsprite -= src
 		return FALSE
 
+//Generate the image based on the mob's current icon and apply matrix transformations
+// to adjust its position and angle
 /mob/living/proc/generate_smallsprite()
 	var/image/I = image(icon=icon, icon_state=icon_state, loc=src, layer=layer, pixel_x=pixel_x, pixel_y=pixel_y)
 	I.overlays += overlays
@@ -64,6 +73,7 @@ GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 	I.transform = ntransform
 	return I
 
+//Called periodically to regenerate the mob's smallsprite
 /mob/living/BiologicalLife(delta_time, times_fired)
 	. = ..()
 	regenerate_smallsprite()

--- a/GainStation13/code/modules/resize/height_limits.dm
+++ b/GainStation13/code/modules/resize/height_limits.dm
@@ -1,0 +1,44 @@
+/mob/
+	var/datum/action/resize_others/resize_others
+	var/see_resized_others = FALSE
+
+/datum/action/resize_others
+	name = "Toggle Others' Giant Sprites"
+	desc = "Others will now look small to you."
+	icon_icon = 'icons/mob/screen_gen_old.dmi'
+	button_icon_state = "health1"		//You can change this if you want
+	background_icon_state = "bg_alien"	//But keep this as a distinct background
+	var/small = FALSE
+	var/image/small_icon
+
+/datum/action/resize_others/Trigger()
+	..()
+	owner.see_resized_others = !owner.see_resized_others
+	return TRUE
+
+/datum/atom_hud/alternate_appearance/basic/showSmall
+
+/datum/atom_hud/alternate_appearance/basic/showSmall/New()
+	..()
+	for(var/mob in GLOB.player_list)
+		if(mobShouldSee(mob))
+			add_hud_to(mob)
+
+/datum/atom_hud/alternate_appearance/basic/blessedAware/mobShouldSee(mob/M)
+	if(M.mind)
+		if(M.see_resized_others == TRUE)
+			return TRUE
+	return FALSE
+
+/datum/action/sizecode_resize/Grant(mob/M, safety=FALSE)
+	if(ishuman(M) && !safety)	//this probably gets called before a person gets overlays on roundstart, so try again
+		if(!LAZYLEN(M.overlays))
+			addtimer(CALLBACK(src,PROC_REF(Grant), M, TRUE), 5)	//https://www.youtube.com/watch?v=QQ-aYZzlDeo
+			return
+
+	..()
+	if(!owner)
+		return
+
+	owner.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/showSmall, "gscode_smallsprite", small_icon, FALSE)
+	message_admins("generated")

--- a/GainStation13/code/modules/resize/height_limits.dm
+++ b/GainStation13/code/modules/resize/height_limits.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 //When switched off, remove from the list and remove smallsprites for the user's hud.
 /client/verb/toggle_others_giant()
 	set name = "Toggle Others' Giant Sprite"
-	set category = "Preferences"
+	set category = "Preferences.GS13"
 	set desc = "Change display settings to and from displaying others' giant sprites."
 	if(!mob.see_resized_others)
 		mob.see_resized_others = !mob.see_resized_others

--- a/GainStation13/code/modules/resize/height_limits.dm
+++ b/GainStation13/code/modules/resize/height_limits.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 * * If the size_multiplier was not higher than one then remove the mob from the list of smallsprite mobs
 */
 /mob/living/proc/regenerate_smallsprite()
-	if(alternate_appearances && alternate_appearances["gscode_smallsprite"])
+	if(length(alternate_appearances) && alternate_appearances["gscode_smallsprite"])
 		for(var/mob/M in GLOB.see_toggle_smallsprite)
 			var/datum/atom_hud/alternate_appearance/AA = alternate_appearances["gscode_smallsprite"]
 			AA.remove_from_single_hud(M, src)

--- a/GainStation13/code/modules/resize/height_limits.dm
+++ b/GainStation13/code/modules/resize/height_limits.dm
@@ -36,11 +36,13 @@ GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 				AA.remove_from_single_hud(mob, L)
 		to_chat(src, "Resize others view toggled OFF.")
 
-//Call to regenerate the sprites and update huds.
-//If present, remove the old sprite from the huds and from the mob
-//If the size_multiplier is still higher than 1, check if the mob is in the list of smallsprite mobs and add it if not
-// add a new sprite by generating it, then go through the list of mobs with smallsprites toggled on and it to their hud
-//If the size_multiplier was not higher than one then remove the mob from the list of smallsprite mobs
+/**
+* Call to regenerate the sprites and update huds.
+* * If present, remove the old sprite from the huds and from the mob
+* * If the size_multiplier is still higher than 1, check if the mob is in the list of smallsprite mobs and add it if not
+* * add a new sprite by generating it, then go through the list of mobs with smallsprites toggled on and it to their hud
+* * If the size_multiplier was not higher than one then remove the mob from the list of smallsprite mobs
+*/
 /mob/living/proc/regenerate_smallsprite()
 	if(alternate_appearances && alternate_appearances["gscode_smallsprite"])
 		for(var/mob/M in GLOB.see_toggle_smallsprite)

--- a/GainStation13/code/modules/resize/height_limits.dm
+++ b/GainStation13/code/modules/resize/height_limits.dm
@@ -6,8 +6,8 @@
 GLOBAL_LIST_EMPTY(enabled_smallsprite)
 GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 
-//var to know if one has the toggle activated or not
 /mob/
+	///var to know if one has the toggle activated or not
 	var/see_resized_others = FALSE
 
 /datum/atom_hud/alternate_appearance/basic/showSmall

--- a/GainStation13/code/modules/resize/height_limits.dm
+++ b/GainStation13/code/modules/resize/height_limits.dm
@@ -19,8 +19,8 @@ GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 	set name = "Toggle Others' Giant Sprite"
 	set category = "Preferences.GS13"
 	set desc = "Change display settings to and from displaying others' giant sprites."
-	if(!mob.see_resized_others)
-		mob.see_resized_others = !mob.see_resized_others
+	mob.see_resized_others = !mob.see_resized_others
+	if(mob.see_resized_others)
 		GLOB.see_toggle_smallsprite += mob
 		for(var/mob/living/L in GLOB.enabled_smallsprite)
 			if(L && L != mob && L.alternate_appearances && L.alternate_appearances["gscode_smallsprite"])
@@ -28,7 +28,6 @@ GLOBAL_LIST_EMPTY(see_toggle_smallsprite)
 				AA.add_to_single_hud(mob, L)
 		to_chat(src, "Resize others view toggled ON.")
 	else
-		mob.see_resized_others = !mob.see_resized_others
 		GLOB.see_toggle_smallsprite -= mob
 		for(var/mob/living/L in GLOB.enabled_smallsprite)
 			if(L && L.alternate_appearances && L.alternate_appearances["gscode_smallsprite"])

--- a/hyperstation/code/modules/arousal/arousalhud.dm
+++ b/hyperstation/code/modules/arousal/arousalhud.dm
@@ -77,6 +77,7 @@
 
 	dat	+=	{"<HR>"}//Newline for the objects
 	//bottom options
+	dat	+= "<a href='byond://?src=[REF(src)];toggle_giant=1'>Toggle others' giant sprites</A>" //GS13 Edit
 	dat	+= "<a href='byond://?src=[REF(src)];refresh=1'>Refresh</A>"
 	dat	+= "<a href='byond://?src=[REF(src)];omenu=1'>Old Menu</A>"
 	dat	+= "<a href='byond://?src=[REF(src)];underwear=1'>Toggle Undergarments </A>"
@@ -279,6 +280,11 @@
 
 	if(href_list["underwear"])
 		H.underwear_toggle()
+		return
+
+	if(href_list["toggle_giant"])
+		if(H && H.client)
+			H.client.toggle_others_giant()
 		return
 
 	src.ui_interact(usr)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4075,6 +4075,7 @@
 #include "GainStation13\code\modules\research\designs\nutri_designs.dm"
 #include "GainStation13\code\modules\research\nanites\nanite_programs\fattening.dm"
 #include "GainStation13\code\modules\research\techweb\nutritech_nodes.dm"
+#include "GainStation13\code\modules\resize\height_limits.dm"
 #include "GainStation13\code\modules\surgery\organs\augments.dm"
 #include "GainStation13\code\modules\surgery\organs\tongue.dm"
 #include "GainStation13\code\modules\vehicles\grocery_cart_scooter.dm"


### PR DESCRIPTION
Added an option in the Preferences tab and in the Arousal menu to toggle on and off smallsprite view, which replaces the sprites of all other mobs with a size larger than 100% with a 100% big sprite
