### PR TITLE
Fixes mice being able to bite wires through catwalks

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -79,6 +79,10 @@
 
 	if(prob(chew_probability))
 		var/turf/open/floor/F = get_turf(src)
+		// GS13 - EDIT
+		if(istype(F, /turf/open/floor/catwalk_floor))
+			return
+		// GS13 - END EDIT
 		if(istype(F) && !F.intact)
 			var/obj/structure/cable/C = locate() in F
 			if(C && prob(15))

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -81,7 +81,9 @@
 		var/turf/open/floor/F = get_turf(src)
 		// GS13 - EDIT
 		if(istype(F, /turf/open/floor/catwalk_floor))
-			return
+			var/turf/open/floor/catwalk_floor/catwalk = F
+			if(catwalk.covered)
+				return
 		// GS13 - END EDIT
 		if(istype(F) && !F.intact)
 			var/obj/structure/cable/C = locate() in F


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As per the title, mice won't be able to bite through wires when covered by catwalks, unless they're open

## Why It's Good For The Game

Fixes a bug