### PR TITLE
small fat damage tweaks

### DIFF
--- a/GainStation13/code/mechanics/fatness.dm
+++ b/GainStation13/code/mechanics/fatness.dm
@@ -274,6 +274,10 @@ GLOBAL_LIST_INIT(uncapped_resize_areas, list(/area/command/bridge, /area/mainten
 	return needed_fatness
 
 /mob/living/carbon/proc/applyFatnessDamage(amount)
+	if(!client?.prefs?.weight_gain_weapons) // If we can't fatten them through weapons, apply stamina damage
+		adjustStaminaLoss(amount)
+		return TRUE
+
 	var/fat_to_add = ((amount * CONFIG_GET(number/damage_multiplier)) * FAT_DAMAGE_TO_FATNESS)
 	adjust_fatness(fat_to_add, FATTENING_TYPE_WEAPON)
 	return fat_to_add

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -279,5 +279,5 @@
 #define FAT 		"fat"
 #define PERMA_FAT 		"perma_fat"
 /// What is the rate that one damage is converted to fatness?
-#define FAT_DAMAGE_TO_FATNESS 4
-#define PERMA_FAT_DAMAGE_TO_FATNESS 4
+#define FAT_DAMAGE_TO_FATNESS 8
+#define PERMA_FAT_DAMAGE_TO_FATNESS 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Updates fat damage to increase to conversion from force to fattening `4` -> `8`
If the target of the fattening damage does not have the proper pref on, the weapon will do stamina damage to the target instead. The stamina damage being equal to the pre-multiplication fattening damage .

## Changelog
:cl:
balance: fattening damage per force is now doubled.
balance: If someone takes fattening damage but doesn't have the pref for it on, they will instead take stamina damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
