### PR TITLE
added custom stuckage chance

### DIFF
--- a/GainStation13/code/machinery/doors/airlock_types.dm
+++ b/GainStation13/code/machinery/doors/airlock_types.dm
@@ -7,6 +7,17 @@
 	if(isnull(stuckage_weight) || (stuckage_weight < 10))
 		return ..() // They aren't able to get stuck
 
+	var/chance_to_get_stuck = L?.client?.prefs?.stuckage_chance * 100
+	if(chance_to_get_stuck && L.fatness > stuckage_weight)
+		if(prob(chance_to_get_stuck))
+			L.doorstuck = 1
+			L.visible_message("<span class'danger'>[L] gets stuck in the doorway!</span>")
+			to_chat(L, "<span class='danger'>As you attempt to pass through  \the [src], your ample curves get wedged in the narrow opening. You find yourself stuck in the [src] frame, struggling to free yourself from the tight squeeze.</span>")
+			L.Stun(55, updating = TRUE, ignore_canstun = TRUE)
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/machinery/door/airlock/, AsyncDoorstuckCall), L), 55)
+		return ..()
+
+
 	if(L.fatness > (stuckage_weight * 2))
 		if(rand(1, 3) == 1)
 			L.doorstuck = 1

--- a/GainStation13/code/modules/client/preferences/preferences.dm
+++ b/GainStation13/code/modules/client/preferences/preferences.dm
@@ -27,6 +27,8 @@
 	var/weight_gain_permanent = FALSE
 	/// At what weight will you start to get stuck in airlocks?
 	var/stuckage = FALSE
+	// Percentage chance to get stuck in doors. Setting this to 0 will make the chance depend on the person's weight
+	var/stuckage_chance = 0
 	/// At what weight will you start to break chairs?
 	var/chair_breakage = FALSE
 	/// Are items that only affect those at high weights able to affect the player?

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -328,6 +328,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		wl_rate = 0.5
 	if(isnull(stuckage))
 		stuckage = 0
+	if (stuckage_chance == null)
+		stuckage_chance = 0
 	if(isnull(max_weight))
 		max_weight = 0
 	if(isnull(chair_breakage))
@@ -1422,6 +1424,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat +="<td width='300px' height='300px' valign='top'>"
 					dat += "<h2>GS13 Gameplay Preferences</h2>"
 					dat += "<b>Stuckage (at what weight will you get stuck in doors?):</b><a href='?_src_=prefs;preference=stuckage'>[stuckage == FALSE ? "Disabled" : stuckage]</a><BR>"
+					if(stuckage)
+						dat += "<b>Stuckage Chance :</b> <a href='?_src_=prefs;preference=stuckage_chance;task=input'>[stuckage_chance]</a><br>"
 					dat += "<b>Chair Breakage (at what weight will you break chairs?):</b><a href='?_src_=prefs;preference=chair_breakage'>[chair_breakage == FALSE ? "Disabled" : chair_breakage]</a><BR>"
 					dat += "<br></br>"
 					dat += "This preference will allow items that work based on weight to work to you, <b>usually to your detriment.</b> <BR>"
@@ -3021,6 +3025,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_wl_rate = input(user, "Choose your weight loss rate from 0.1 (10%) to 2 (200%).\n Decimals such as 0.2 indicate 20% rate.\nDefault recommended rate is 0.5 (50%)", "Character Preference", wl_rate) as num|null
 					if (new_wl_rate)
 						wl_rate = max(min(round(text2num(new_wl_rate),0.01),2),0)
+				
+				if("stuckage_chance")
+					var/new_stuckage_chance = input(user, "Choose your chance to get stuck in doors from 0.1 (10%) to 1 (100%).\nDecimals such as 0.2 indicate 20% chance.\nSetting this to 0 restores default values.", "Character Preference", stuckage_chance) as num|null
+					if(new_stuckage_chance)
+						stuckage_chance = clamp(new_stuckage_chance, 0.1, 1)
+					else
+						stuckage_chance = 0
 
 				if("marking_down")
 					// move the specified marking down

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -952,6 +952,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["helplessness_clothing_back"] >> helplessness_clothing_back
 	S["helplessness_no_buckle"] >> helplessness_no_buckle
 	S["stuckage"] >> stuckage
+	S["stuckage_chance"] >> stuckage_chance
 	S["chair_breakage"] >> chair_breakage
 	S["fatness_vulnerable"] >> fatness_vulnerable
 	S["extreme_fatness_vulnerable"] >> extreme_fatness_vulnerable
@@ -1247,6 +1248,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["helplessness_clothing_back"], helplessness_clothing_back)
 	WRITE_FILE(S["helplessness_no_buckle"], helplessness_no_buckle)
 	WRITE_FILE(S["stuckage"], stuckage)
+	WRITE_FILE(S["stuckage_chance"], stuckage_chance)
 	WRITE_FILE(S["chair_breakage"], chair_breakage)
 	WRITE_FILE(S["fatness_vulnerable"], fatness_vulnerable)
 	WRITE_FILE(S["extreme_fatness_vulnerable"], extreme_fatness_vulnerable)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows the player to set a custom stuckage chance, between 10 and 100%. When set, it overrides the stuckage chance based on weight. When set to 0, it uses the default stuckage mechanics.

## Why It's Good For The Game

People complain about getting stuck too often. ~~Maybe they should just lose some weight.~~ This will allow them to partake in getting stuck without getting annoyed too much.
