### PR TITLE
Fix for ethereals being unable to gain weight from food

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -16,7 +16,7 @@
 	damage_overlay_type = "" //We are too cool for regular damage overlays
 	species_traits = list(MUTCOLORS, HAIR, HAS_FLESH, HAS_BONE) // i mean i guess they have blood so they can have wounds too
 	species_language_holder = /datum/language_holder/ethereal
-	inherent_traits = list(TRAIT_NOHUNGER)
+	inherent_traits = list() //GS13 Edit: Our electric brethren want to be fat too
 	sexes = FALSE
 	toxic_food = NONE
 	/*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Some others mentioned Ethereals couldn't gain weight at all from eating, this changes that. There wasn't any immediate issues with their liquid electricity food mechanic from what I was able to test.

![image (28)](https://github.com/user-attachments/assets/49d18828-f2fe-4a28-a0dc-e1e2a124f277)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Our electric brethren want to be fat too
## Changelog
:cl:
tweak: Ethereals can gain weight from food now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
