### PR TITLE
IPC APC charging tweak

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -360,6 +360,12 @@
 
 /obj/item/apc_powercord/proc/apc_powerdraw_loop(obj/machinery/power/apc/A, mob/living/carbon/human/H)
 	H.visible_message("<span class='notice'>[H] inserts a power connector into [A].</span>", "<span class='notice'>You begin to draw power from [A].</span>")
+
+	//GS13 edit
+	var/overcharge = FALSE
+	if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+		overcharge = TRUE
+
 	while(do_after(H, 10, target = A))
 		if(loc != H)
 			to_chat(H, "<span class='warning'>You must keep your connector out while charging!</span>")
@@ -378,14 +384,25 @@
 			A.cell.use(A.cell.charge)
 			to_chat(H, "<span class='notice'>You siphon off as much as [A] can spare.</span>")
 			break
-		if(H.nutrition > NUTRITION_LEVEL_FAT) //GS13 edit; I considered uncapped but it drains APCs and fattens stupid fast. could be fun uncapped but speed would need tweaking
-			to_chat(H, "<span class='notice'>You are now fully charged.</span>")
-			break
+		if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+			if(!overcharge) //GS13 edit
+				to_chat(H, "<span class='notice'>You are now fully charged.</span>")
+				break
+			else
+				if(H.nutrition >= NUTRITION_LEVEL_FAT)
+					to_chat(H, "<span class='notice'>You've packed as much extra power into your battery as it can handle.</span>")
+					break
 	in_use = FALSE
 	H.visible_message("<span class='notice'>[H] unplugs from [A].</span>", "<span class='notice'>You unplug from [A].</span>")
 
 /obj/item/apc_powercord/proc/cell_powerdraw_loop(obj/item/stock_parts/cell/C, mob/living/carbon/human/H)
 	H.visible_message("<span class='notice'>[H] connects a power cord to [C]</span>", "<span class='notice'>You begin to draw power from [C].</span>")
+
+		//GS13 edit
+	var/overcharge = FALSE
+	if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+		overcharge = TRUE
+
 	while(do_after(H, 10, target = C))
 		if(loc != H)
 			to_chat(H, "<span class='warning'>You must keep your connector out while charging!</span>")
@@ -397,8 +414,13 @@
 		C.use(siphoned_charge)
 		do_sparks(1, FALSE, C)
 		H.adjust_nutrition(siphoned_charge / 100)	//Less efficient on a pure power basis than APC recharge. Still a very viable way of gaining nutrition. (100 nutrition / base 10k cell)
-		if(H.nutrition > NUTRITION_LEVEL_FAT) //GS13 edit, as above
-			to_chat(H, "<span class='notice'>You are now fully charged.</span>")
-			break
+		if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+			if(!overcharge) //GS13 edit
+				to_chat(H, "<span class='notice'>You are now fully charged.</span>")
+				break
+			else
+				if(H.nutrition >= NUTRITION_LEVEL_FAT)
+					to_chat(H, "<span class='notice'>You've packed as much extra power into your battery as it can handle.</span>")
+					break
 	in_use = FALSE
 	H.visible_message("<span class='notice'>[H] disconnects [src] from [C].</span>", "<span class='notice'>You disconnect from [C].</span>")

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -414,13 +414,15 @@
 		C.use(siphoned_charge)
 		do_sparks(1, FALSE, C)
 		H.adjust_nutrition(siphoned_charge / 100)	//Less efficient on a pure power basis than APC recharge. Still a very viable way of gaining nutrition. (100 nutrition / base 10k cell)
+		// GS13 EDIT START
 		if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
-			if(!overcharge) //GS13 edit
+			if(!overcharge)
 				to_chat(H, "<span class='notice'>You are now fully charged.</span>")
 				break
 			else
 				if(H.nutrition >= NUTRITION_LEVEL_FAT)
 					to_chat(H, "<span class='notice'>You've packed as much extra power into your battery as it can handle.</span>")
 					break
+		//GS13 EDIT END	
 	in_use = FALSE
 	H.visible_message("<span class='notice'>[H] disconnects [src] from [C].</span>", "<span class='notice'>You disconnect from [C].</span>")

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -384,7 +384,8 @@
 			A.cell.use(A.cell.charge)
 			to_chat(H, "<span class='notice'>You siphon off as much as [A] can spare.</span>")
 			break
-		if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+		//GS13 EDIT START
+		if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)	
 			if(!overcharge) //GS13 edit
 				to_chat(H, "<span class='notice'>You are now fully charged.</span>")
 				break
@@ -392,6 +393,7 @@
 				if(H.nutrition >= NUTRITION_LEVEL_FAT)
 					to_chat(H, "<span class='notice'>You've packed as much extra power into your battery as it can handle.</span>")
 					break
+		//GS13 EDIT END
 	in_use = FALSE
 	H.visible_message("<span class='notice'>[H] unplugs from [A].</span>", "<span class='notice'>You unplug from [A].</span>")
 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -361,10 +361,11 @@
 /obj/item/apc_powercord/proc/apc_powerdraw_loop(obj/machinery/power/apc/A, mob/living/carbon/human/H)
 	H.visible_message("<span class='notice'>[H] inserts a power connector into [A].</span>", "<span class='notice'>You begin to draw power from [A].</span>")
 
-	//GS13 edit
+	//GS13 EDIT START
 	var/overcharge = FALSE
 	if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
 		overcharge = TRUE
+	//GS13 EDIT END
 
 	while(do_after(H, 10, target = A))
 		if(loc != H)

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -378,7 +378,7 @@
 			A.cell.use(A.cell.charge)
 			to_chat(H, "<span class='notice'>You siphon off as much as [A] can spare.</span>")
 			break
-		if(H.nutrition > NUTRITION_LEVEL_WELL_FED)
+		if(H.nutrition > NUTRITION_LEVEL_FAT) //GS13 edit; I considered uncapped but it drains APCs and fattens stupid fast. could be fun uncapped but speed would need tweaking
 			to_chat(H, "<span class='notice'>You are now fully charged.</span>")
 			break
 	in_use = FALSE
@@ -397,7 +397,7 @@
 		C.use(siphoned_charge)
 		do_sparks(1, FALSE, C)
 		H.adjust_nutrition(siphoned_charge / 100)	//Less efficient on a pure power basis than APC recharge. Still a very viable way of gaining nutrition. (100 nutrition / base 10k cell)
-		if(H.nutrition > NUTRITION_LEVEL_WELL_FED)
+		if(H.nutrition > NUTRITION_LEVEL_FAT) //GS13 edit, as above
 			to_chat(H, "<span class='notice'>You are now fully charged.</span>")
 			break
 	in_use = FALSE

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -398,10 +398,11 @@
 /obj/item/apc_powercord/proc/cell_powerdraw_loop(obj/item/stock_parts/cell/C, mob/living/carbon/human/H)
 	H.visible_message("<span class='notice'>[H] connects a power cord to [C]</span>", "<span class='notice'>You begin to draw power from [C].</span>")
 
-		//GS13 edit
+	//GS13 EDIT START
 	var/overcharge = FALSE
 	if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
 		overcharge = TRUE
+	//GS13 EDIT END
 
 	while(do_after(H, 10, target = C))
 		if(loc != H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tweaks the IPC power cord implant to auto detach at fat nutrition level instead of well-fed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was already intended (see line 343) but implemented in a way where it still detaches at well-fed
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: IPC power cord implant can be connected while already fully charged to overcharge for extra nutrition and weight gain
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
