### PR TITLE
SSD Timer on Examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -371,7 +371,7 @@
 			if(!key)
 				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)
-				msg += "[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.\n"
+				msg += "[t_He] [t_has] a blank, absent-minded stare and [t_has] been completely unresponsive to anything for [round(((world.time - lastclienttime) / (1 MINUTES)),1)] minutes. [t_He] may snap out of it soon.\n" //GS13 Edit: SSD timer
 
 		if(digitalcamo)
 			msg += "[t_He] [t_is] moving [t_his] body in an unnatural and blatantly inhuman manner.\n"

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -524,6 +524,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			if(!SSD)
 				add_status_indicator("ssd")
 				SSD = TRUE
+				lastclienttime = world.time //GS13 Editception: SSD timer
 		else
 			if(SSD)
 				remove_status_indicator("ssd")

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -92,6 +92,7 @@
 
 	// GS13 EDIT
 	var/SSD = FALSE
+	var/lastclienttime = 0 //GS13 Editception: SSD timer
 
 	var/list/pipes_shown = list()
 	var/last_played_vent


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Introduces a timer to show how long a player has been SSD for when examining them, works when observing and living.  Special thanks to Skyrat for providing the basis for this as seen here: https://github.com/Skyrat-SS13/Skyrat-tg/pull/1325

![ssd](https://github.com/user-attachments/assets/d67ac913-9802-452a-be1d-97f8ba8552a8)

 
Tested on a local server copy with my own account and a guest account, no immediate problems found.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fulfills a suggestion within the summarized list and allows people to see how long someone has mostly been SSD for.

## Changelog
:cl:
qol: Examine timer to show how long a player has been SSD for. Thanks to Skyrat for providing the basis.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
