### PR TITLE
Dance pole and clothesmate resupply pack in cargo

### DIFF
--- a/GainStation13/code/modules/cargo/packs.dm
+++ b/GainStation13/code/modules/cargo/packs.dm
@@ -31,9 +31,24 @@
 	crate_name = "strange seeds crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
+/datum/supply_pack/misc/stripperpole //oldcode port
+	name = "Stripper Pole Crate"
+	desc = "No private bar is complete without a stripper pole, show off the goods! Comes with a ready-to-assemble stripper pole, and a complementary wrench to get things set up!"
+	cost = 3550
+	contains = list(/obj/item/polepack,
+					/obj/item/wrench)
+	crate_name = "stripper pole crate"
+
 /datum/supply_pack/critter/fennec //ported from CHOMPstation2
 	name = "Fennec Crate"
 	desc = "Why so ears?"
 	cost = 5000
 	contains = list(/mob/living/simple_animal/pet/fox/fennec)
 	crate_name = "fennec crate"
+
+/datum/supply_pack/vending/wardrobes/clothing //existing game item not in cargo for some reason
+	name = "ClothesMate Supply Crate"
+	desc = "ClothesMate missing your favorite outfit? Solve that issue today with this autodrobe refill."
+	cost = 1500
+	contains = list(/obj/item/vending_refill/clothing)
+	crate_name = "clothesmate supply crate"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4158,6 +4158,7 @@
 #include "hyperstation\code\obj\decal.dm"
 #include "hyperstation\code\obj\fleshlight.dm"
 #include "hyperstation\code\obj\kinkyclothes.dm"
+#include "hyperstation\code\obj\pole.dm"
 #include "hyperstation\code\obj\sizeitems.dm"
 #include "hyperstation\code\obj\stargate_clothing.dm"
 #include "hyperstation\code\obj\ZaoCorp\hat.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Restores the missing dancing pole and clothesmate restock pack to cargo catalogue, changes integrated into the cargo packs file in the server specific folder.

![clothespole](https://github.com/user-attachments/assets/472ee2d5-43ee-47d6-9871-68bf48c71cd9)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Restores missing content in the code transition.

## Changelog
:cl:
add: Dancing pole from oldcode, buyable from cargo
add: ClothesMate refill pack, buyable from cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
