### PR TITLE
Telebaton damage re-buff

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -405,8 +405,8 @@
 	off_icon_state = "telebaton_0"
 	on_item_state = "telebaton_1"
 	force_on = 10
-	cooldown = 40 //gs13 change - telebaton nerf
-	stam_dmg = 10 //gs13 change - telebaton nerf
+	cooldown = 40 //gs13 change - telebaton balancing
+	stam_dmg = 40 //gs13 change - telebaton balancing
 	force_off = 0
 	weight_class_on = WEIGHT_CLASS_BULKY
 	total_mass = TOTAL_MASS_NORMAL_ITEM


### PR DESCRIPTION
## About The Pull Request

Brings the telebaton stamina damage up, while keeping the cooldown long, to allow it to stamcrit on it's own and allow it to be a viable weapon in combat.

## Why It's Good For The Game

The telebaton is the heads of staff main and often only weapon for self defense, and as such should be at least capable of being used as a self defense weapon all on it's own. This change allows the telebaton to drain someone's stamina into a stam crit, while also keeping the hit cooldown long as to make it less of an insta win button.